### PR TITLE
`create flow` and `add flow` commands

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -18,6 +18,7 @@ cobra-cli add version --license mit --author "Open Traffic Generator"
 cobra-cli add transform --license mit --author "Open Traffic Generator"
 cobra-cli add display --license mit --author "Open Traffic Generator"
 cobra-cli add create --license mit --author "Open Traffic Generator"
+cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create
 ````
 
 ### GoReleaser

--- a/BUILD.md
+++ b/BUILD.md
@@ -18,7 +18,8 @@ cobra-cli add version --license mit --author "Open Traffic Generator"
 cobra-cli add transform --license mit --author "Open Traffic Generator"
 cobra-cli add display --license mit --author "Open Traffic Generator"
 cobra-cli add create --license mit --author "Open Traffic Generator"
-cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create
+cobra-cli add add --license mit --author "Open Traffic Generator"
+cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create and add
 ````
 
 ### GoReleaser

--- a/BUILD.md
+++ b/BUILD.md
@@ -17,6 +17,7 @@ cobra-cli add run --license mit --author "Open Traffic Generator"
 cobra-cli add version --license mit --author "Open Traffic Generator"
 cobra-cli add transform --license mit --author "Open Traffic Generator"
 cobra-cli add display --license mit --author "Open Traffic Generator"
+cobra-cli add create --license mit --author "Open Traffic Generator"
 ````
 
 ### GoReleaser

--- a/BUILD.md
+++ b/BUILD.md
@@ -20,6 +20,7 @@ cobra-cli add display --license mit --author "Open Traffic Generator"
 cobra-cli add create --license mit --author "Open Traffic Generator"
 cobra-cli add add --license mit --author "Open Traffic Generator"
 cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create and add
+cobra-cli add device --license mit --author "Open Traffic Generator" # subcommand for create and add
 ````
 
 ### GoReleaser

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ otgen display --mode table
 
 ## Environmental variables
 
-Use env variables to define values of the following OTG attibutes:
+Use env variables to define values of the following OTG attributes:
 
 ```Shell
 OTG_LOCATION_P1                       # location for test port "p1"
@@ -57,7 +57,7 @@ export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ### `create` and `add`
 
 Create a new OTG configuration item that can be further passed to stdin of `otgen run` command.
-The `add` variant of the command first reads an OTG configuraton from stdin.
+The `add` variant of the command first reads an OTG configuration from stdin.
 
 ```Shell
 otgen create flow                     # Create OTG flow configuration (default)
@@ -73,7 +73,7 @@ otgen create flow                     # Create OTG flow configuration (default)
   [--dst x.x.x.x]                     # Destination IP address
   [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet
   [--dport N]                         # Destination TCP or UDP port (default 7 - echo protocol)
-  [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
+  [--count N]                         # Number of packets to transmit. Use 0 for continuous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
   [--loss]                            # Enable loss metrics

--- a/README.md
+++ b/README.md
@@ -29,10 +29,10 @@ otgen create
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
-  [--sport N]                         # Source TCP or UDP port
+  [--sport N]                         # Source TCP or UDP port. If not specified, an incremental set of source ports would be used for each packet
   [--dport N]                         # Destination TCP or UDP port
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
-  [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine.
+  [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine.
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Create OTG configuration that can be further passed to stdin of `otgen run` comm
 ```Shell
 otgen create
   [ flow ]                            # Create OTG flow configuration (default)
-  [ ipv4 | ipv6 ]                     # IP version (default ipv4)
+  [--ipv4 ]                           # IP version 4 (default)
+  [--ipv6 ]                           # IP version 6
   [--name string]                     # Flow name (default f1)
   [--proto icmp | tcp | udp]          # IP transport protocol
   [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address

--- a/README.md
+++ b/README.md
@@ -35,6 +35,10 @@ otgen create
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
+  [--loss]                            # Enable loss metrics
+  [--latency]                         # Enable latency metrics
+  [--timestamps]                      # Enable metrics timestamps
+  [--nometrics ]                      # Disable flow metrics
 ```
 
 ### `run`

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API 
 The pipe workflow on `otgen` looks the following:
 
 ```Shell
-otgen create tcp -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | otgen run --metrics flow | otgen transform --metrics flow --counters frames | otgen display --mode table
+otgen create flow -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | otgen run --metrics flow | otgen transform --metrics flow --counters frames | otgen display --mode table
 ````
 
 ## Command reference
@@ -24,7 +24,7 @@ Create OTG configuration that can be further passed to stdin of `otgen run` comm
 otgen create
   [ flow ]                            # Create OTG flow configuration (default)
   [ ipv4 | ipv6 ]                     # IP version (default ipv4)
-  icmp | tcp | udp                    # IP protocol
+  [--proto icmp | tcp | udp]          # IP transport protocol
   [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
   [--src x.x.x.x]                     # Source IP address

--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API 
 The pipe workflow on `otgen` looks the following:
 
 ```Shell
-otgen create flow -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | otgen run --metrics flow | otgen transform --metrics flow --counters frames | otgen display --mode table
+otgen create flow -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | \
+otgen run --metrics flow | \
+otgen transform --metrics flow --counters frames | \
+otgen display --mode table
 ````
 
 ## Command reference
@@ -23,9 +26,9 @@ Create OTG configuration that can be further passed to stdin of `otgen run` comm
 ```Shell
 otgen create
   [ flow ]                            # Create OTG flow configuration (default)
+  [--name string]                     # Flow name (default f1)
   [--ipv4 ]                           # IP version 4 (default)
   [--ipv6 ]                           # IP version 6
-  [--name string]                     # Flow name (default f1)
   [--proto icmp | tcp | udp]          # IP transport protocol
   [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
@@ -37,7 +40,7 @@ otgen create
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
   [--loss]                            # Enable loss metrics
-  [--latency]                         # Enable latency metrics
+  [--latency sf | ct]                 # Enable latency metrics: sf for store_forward | ct for cut_through
   [--timestamps]                      # Enable metrics timestamps
   [--nometrics ]                      # Disable flow metrics
 ```

--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Environmental variables is one of the mechanisms used by `otgen` to control defa
 
 ```Shell
 OTG_LOCATION_%PORT_NAME%              # location for test port with a name PORT_NAME, for example:
+OTG_LOCATION_P1                       # location for test port "p1"
+OTG_LOCATION_P2                       # location for test port "p2"
 
 OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
 OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ otgen create
   [ flow ]                            # Create OTG flow configuration (default)
   [ ipv4 | ipv6 ]                     # IP version (default ipv4)
   icmp | tcp | udp                    # IP protocol
-  --src x.x.x.x                       # Source IP address
-  --dst x.x.x.x                       # Destination IP address
+  [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
+  [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
+  [--src x.x.x.x]                     # Source IP address
+  [--dst x.x.x.x]                     # Destination IP address
   --port N                            # Destination TCP or UDP port
   --rate N                            # Packet rate in packets per second
 ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ otgen create
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
   --port N                            # Destination TCP or UDP port
-  --rate N                            # Packet rate in packets per second
+  [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
+  [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine.
 ```
 
 ### `run`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@ otgen display --mode table
 
 ## Environmental variables
 
-Use env variables to define values of the following OTG attributes:
+Values of certain parameters in the OTG configuration depend on the specifics of the traffic generator deployment. These values would typically stay the same between multiple `otgen` executions as long as the traffic generator deployment stays the same. For example:
+ 
+   * `location` string of the OTG `ports` depends on which specific port instance we want to use, and how OTG Controller can connect to that instance
+   * MAC addresses for OTG `flows` change only after re-deployment of containerized traffic generator components, and don't change in hardware setups
+
+For such parameters it may be more convinient to change default values used by `otgen` instead of specifying them as command-line arguments.
+
+Environmental variables is one of the mechanisms used by `otgen` to control default values. See the full list of ENV vars recognized by `otgen` to redefine default values.
 
 ```Shell
 OTG_LOCATION_P1                       # location for test port "p1"
@@ -51,6 +58,8 @@ export OTG_FLOW_DST_IPV4="192.0.2.2"
 export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
 export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ```
+
+Note, default values displayed via built-in `--help` output reflect currently set environmental variables values.
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ otgen create tcp -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | otgen run --metrics f
 
 ### `create`
 
-Create OTG configuration that can be further passed to stdin of otgen run command.
+Create OTG configuration that can be further passed to stdin of `otgen run` command.
 
 ```Shell
 otgen create
@@ -29,7 +29,7 @@ otgen create
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
-  [--sport N]                         # Source TCP or UDP port. If not specified, an incremental set of source ports would be used for each packet
+  [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for new packet
   [--dport N]                         # Destination TCP or UDP port
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The pipe workflow on `otgen` looks the following:
 
 ```Shell
 otgen create flow -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | \
+otgen add flow -n f2 -s 2.2.2.2 -d 1.1.1.1 --sport 80 --dport 1024 --tx p2 --rx p1 | \
 otgen run --metrics flow | \
 otgen transform --metrics flow --counters frames | \
 otgen display --mode table
@@ -51,12 +52,12 @@ export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
 export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ```
 
-
 ## Command reference
 
-### `create`
+### `create` and `add`
 
-Create OTG configuration that can be further passed to stdin of `otgen run` command.
+Create a new OTG configuration item that can be further passed to stdin of `otgen run` command.
+The `add` variant of the command first reads an OTG configuraton from stdin.
 
 ```Shell
 otgen create

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ otgen display --mode table
 
 ## Environmental variables
 
-Values of certain parameters in the OTG configuration depend on the specifics of the traffic generator deployment. These values would typically stay the same between multiple `otgen` executions as long as the traffic generator deployment stays the same. For example:
+Values of certain parameters in the OTG configuration depend on specifics of the traffic generator deployment. These values would typically stay the same between multiple `otgen` runs as long as the deployment stays the same. 
+
+For example:
  
-   * `location` string of the OTG `ports` depends on which specific port instance we want to use, and how OTG Controller can connect to that instance
+   * `location` string of the OTG `ports` section depends on traffic generator ports available for the test
    * MAC addresses for OTG `flows` change only after re-deployment of containerized traffic generator components, and don't change in hardware setups
 
 For such parameters it may be more convinient to change default values used by `otgen` instead of specifying them as command-line arguments.
 
-Environmental variables is one of the mechanisms used by `otgen` to control default values. See the full list of ENV vars recognized by `otgen` to redefine default values.
+Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
 
 ```Shell
 OTG_LOCATION_P1                       # location for test port "p1"
@@ -44,7 +46,7 @@ OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
 OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flows
 ```
 
-For example:
+These are the values `otgen` uses if no variables or arguments were provided.
 
 ```Shell
 export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) listening on localhost:5555

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ OTG_LOCATION_P1                       # location for port "p1" – flow tx port
 OTG_LOCATION_P2                       # location for port "p2" - flow rx port
 OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with tx on port "p1"
 OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with tx on port "p1"
+OTG_FLOW_SRC_IPV4                     # Source IPv4 address to use for flows
+OTG_FLOW_DST_IPV4                     # Destination IPv4 address to use for flows
+OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
+OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flows
 ```
 
 For example:
@@ -35,6 +39,10 @@ export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) 
 export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
 export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"
 export OTG_FLOW_DMAC_P1="02:00:00:00:02:aa"
+export OTG_FLOW_SRC_IPV4="192.0.2.1"
+export OTG_FLOW_DST_IPV4="192.0.2.2"
+export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
+export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ````
 
+## Environmental variables
+
+Use env variables to define values of the following OTG attibutes:
+
+```Shell
+OTG_LOCATION_P1                       # location for port "p1" – flow tx port
+OTG_LOCATION_P2                       # location for port "p2" - flow rx port
+```
+
 ## Command reference
 
 ### `create`

--- a/README.md
+++ b/README.md
@@ -24,7 +24,19 @@ Use env variables to define values of the following OTG attibutes:
 ```Shell
 OTG_LOCATION_P1                       # location for port "p1" – flow tx port
 OTG_LOCATION_P2                       # location for port "p2" - flow rx port
+OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with tx on port "p1"
+OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with tx on port "p1"
 ```
+
+For example:
+
+```Shell
+export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) listening on localhost:5555
+export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
+export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"
+export OTG_FLOW_DMAC_P1="02:00:00:00:02:aa"
+```
+
 
 ## Command reference
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ````
 
-Port locations are read from `ENV:OTG_LOCATION_P1` and `ENV:OTG_LOCATION_P2`.
-
-See [Environmental variables](#environmental-variables) section for more options.
-
 ## Command reference
 
 ### `create` and `add`
@@ -30,10 +26,12 @@ Create a new OTG configuration item that can be further passed to stdin of `otge
 The `add` variant of the command first reads an OTG configuration from stdin.
 
 ```Shell
-otgen create flow                     # Create OTG flow configuration (default)
+otgen create flow                     # Create OTG flow configuration
   [--name string]                     # Flow name (default f1)
-  [--tx portname]                     # Test port name for TX (default p1) 
-  [--rx portname]                     # Test port name for RX (default p2) 
+  [--tx string]                       # Test port name for TX (default p1) 
+  [--rx string]                       # Test port name for RX (default p2) 
+  [--txl string]                      # Test port location string for TX (default localhost:5555) 
+  [--rxl string]                      # Test port location string for RX (default localhost:5556) 
   [--ipv4 ]                           # IP version 4 (default)
   [--ipv6 ]                           # IP version 6
   [--proto icmp | tcp | udp]          # IP transport protocol
@@ -43,6 +41,7 @@ otgen create flow                     # Create OTG flow configuration (default)
   [--dst x.x.x.x]                     # Destination IP address
   [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet
   [--dport N]                         # Destination TCP or UDP port (default 7 - echo protocol)
+  [--swap]                            # Swap default values of: Tx and Rx names and locations; source and destination MACs, IPs and TCP/UDP ports
   [--count N]                         # Number of packets to transmit. Use 0 for continuous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
@@ -51,6 +50,18 @@ otgen create flow                     # Create OTG flow configuration (default)
   [--timestamps]                      # Enable metrics timestamps
   [--nometrics ]                      # Disable flow metrics
 ```
+
+```Shell
+otgen create device                   # Create OTG device configuration
+  [--name string]                     # Device name (default otg1)
+  [--port string]                     # Test port name (default p1)
+  [--location string]                 # Test port location string (default localhost:5555)
+  [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
+  [--ip x.x.x.x]                      # Device IP address
+  [--gw x.x.x.x]                      # Device default gateway
+  [--prefix nn]                       # Device network prefix
+```
+
 
 ### `run`
 
@@ -124,8 +135,7 @@ For such parameters it may be more convinient to change default values used by `
 Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
 
 ```Shell
-OTG_LOCATION_P1                       # location for test port "p1"
-OTG_LOCATION_P2                       # location for test port "p2"
+OTG_LOCATION_%PORT_NAME%              # location for test port with a name PORT_NAME, for example:
 
 OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
 OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
@@ -153,4 +163,4 @@ export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
 export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ```
 
-Note, default values displayed via built-in `--help` output reflect currently set environmental variables values.
+Note, default values displayed via built-in `--help` output reflect currently set environmental variables values, except for test port location strings.

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ otgen create
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
-  [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for new packet
-  [--dport N]                         # Destination TCP or UDP port
+  [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet
+  [--dport N]                         # Destination TCP or UDP port (default 7 - echo protocol)
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
-  [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine.
+  [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
 ```
 
 ### `run`

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Create OTG configuration that can be further passed to stdin of `otgen run` comm
 otgen create
   [ flow ]                            # Create OTG flow configuration (default)
   [ ipv4 | ipv6 ]                     # IP version (default ipv4)
+  [--name string]                     # Flow name (default f1)
   [--proto icmp | tcp | udp]          # IP transport protocol
   [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address

--- a/README.md
+++ b/README.md
@@ -22,10 +22,14 @@ otgen display --mode table
 Use env variables to define values of the following OTG attibutes:
 
 ```Shell
-OTG_LOCATION_P1                       # location for port "p1" – flow tx port
-OTG_LOCATION_P2                       # location for port "p2" - flow rx port
-OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with tx on port "p1"
-OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with tx on port "p1"
+OTG_LOCATION_P1                       # location for test port "p1"
+OTG_LOCATION_P2                       # location for test port "p2"
+
+OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
+OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
+OTG_FLOW_SMAC_P2                      # Source MAC address to use for flows with Tx on port "p2"
+OTG_FLOW_DMAC_P2                      # Destination MAC address to use for flows with Tx on port "p2"
+
 OTG_FLOW_SRC_IPV4                     # Source IPv4 address to use for flows
 OTG_FLOW_DST_IPV4                     # Destination IPv4 address to use for flows
 OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
@@ -39,6 +43,8 @@ export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) 
 export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
 export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"
 export OTG_FLOW_DMAC_P1="02:00:00:00:02:aa"
+export OTG_FLOW_SMAC_P2="02:00:00:00:02:aa"
+export OTG_FLOW_DMAC_P2="02:00:00:00:01:aa"
 export OTG_FLOW_SRC_IPV4="192.0.2.1"
 export OTG_FLOW_DST_IPV4="192.0.2.2"
 export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
@@ -56,6 +62,8 @@ Create OTG configuration that can be further passed to stdin of `otgen run` comm
 otgen create
   [ flow ]                            # Create OTG flow configuration (default)
   [--name string]                     # Flow name (default f1)
+  [--tx portname]                     # Test port name for TX (default p1) 
+  [--rx portname]                     # Test port name for RX (default p2) 
   [--ipv4 ]                           # IP version 4 (default)
   [--ipv6 ]                           # IP version 6
   [--proto icmp | tcp | udp]          # IP transport protocol

--- a/README.md
+++ b/README.md
@@ -18,50 +18,9 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ````
 
-## Environmental variables
+Port locations are read from `ENV:OTG_LOCATION_P1` and `ENV:OTG_LOCATION_P2`.
 
-Values of certain parameters in the OTG configuration depend on specifics of the traffic generator deployment. These values would typically stay the same between multiple `otgen` runs as long as the deployment stays the same. 
-
-For example:
- 
-   * `location` string of the OTG `ports` section depends on traffic generator ports available for the test
-   * MAC addresses for OTG `flows` change only after re-deployment of containerized traffic generator components, and don't change in hardware setups
-
-For such parameters it may be more convinient to change default values used by `otgen` instead of specifying them as command-line arguments.
-
-Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
-
-```Shell
-OTG_LOCATION_P1                       # location for test port "p1"
-OTG_LOCATION_P2                       # location for test port "p2"
-
-OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
-OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
-OTG_FLOW_SMAC_P2                      # Source MAC address to use for flows with Tx on port "p2"
-OTG_FLOW_DMAC_P2                      # Destination MAC address to use for flows with Tx on port "p2"
-
-OTG_FLOW_SRC_IPV4                     # Source IPv4 address to use for flows
-OTG_FLOW_DST_IPV4                     # Destination IPv4 address to use for flows
-OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
-OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flows
-```
-
-These are the values `otgen` uses if no variables or arguments were provided.
-
-```Shell
-export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) listening on localhost:5555
-export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
-export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"
-export OTG_FLOW_DMAC_P1="02:00:00:00:02:aa"
-export OTG_FLOW_SMAC_P2="02:00:00:00:02:aa"
-export OTG_FLOW_DMAC_P2="02:00:00:00:01:aa"
-export OTG_FLOW_SRC_IPV4="192.0.2.1"
-export OTG_FLOW_DST_IPV4="192.0.2.2"
-export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
-export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
-```
-
-Note, default values displayed via built-in `--help` output reflect currently set environmental variables values.
+See [Environmental variables](#environmental-variables) section for more options.
 
 ## Command reference
 
@@ -150,3 +109,48 @@ To check `otgen` version you have, use
 ```Shell
 otgen version
 ````
+
+## Environmental variables
+
+Values of certain parameters in the OTG configuration depend on specifics of the traffic generator deployment. These values would typically stay the same between multiple `otgen` runs as long as the deployment stays the same. 
+
+For example:
+ 
+   * `location` string of the OTG `ports` section depends on traffic generator ports available for the test
+   * MAC addresses for OTG `flows` change only after re-deployment of containerized traffic generator components, and don't change in hardware setups
+
+For such parameters it may be more convinient to change default values used by `otgen` instead of specifying them as command-line arguments.
+
+Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
+
+```Shell
+OTG_LOCATION_P1                       # location for test port "p1"
+OTG_LOCATION_P2                       # location for test port "p2"
+
+OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
+OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
+OTG_FLOW_SMAC_P2                      # Source MAC address to use for flows with Tx on port "p2"
+OTG_FLOW_DMAC_P2                      # Destination MAC address to use for flows with Tx on port "p2"
+
+OTG_FLOW_SRC_IPV4                     # Source IPv4 address to use for flows
+OTG_FLOW_DST_IPV4                     # Destination IPv4 address to use for flows
+OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
+OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flows
+```
+
+These are the values `otgen` uses if no variables or arguments were provided.
+
+```Shell
+export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) listening on localhost:5555
+export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
+export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"
+export OTG_FLOW_DMAC_P1="02:00:00:00:02:aa"
+export OTG_FLOW_SMAC_P2="02:00:00:00:02:aa"
+export OTG_FLOW_DMAC_P2="02:00:00:00:01:aa"
+export OTG_FLOW_SRC_IPV4="192.0.2.1"
+export OTG_FLOW_DST_IPV4="192.0.2.2"
+export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
+export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
+```
+
+Note, default values displayed via built-in `--help` output reflect currently set environmental variables values.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ otgen create
   --port N                            # Destination TCP or UDP port
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine.
+  [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine.
 ```
 
 ### `run`

--- a/README.md
+++ b/README.md
@@ -11,14 +11,29 @@ The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API 
 The pipe workflow on `otgen` looks the following:
 
 ```Shell
-otgen create tcp -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000pps | otgen run --metrics flow | otgen transform --metrics flow --counters frames | otgen display --mode table
+otgen create tcp -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | otgen run --metrics flow | otgen transform --metrics flow --counters frames | otgen display --mode table
 ````
 
 ## Command reference
 
+### `create`
+
+Create OTG configuration that can be further passed to stdin of otgen run command.
+
+```Shell
+otgen create
+  [ flow ]                            # Create OTG flow configuration (default)
+  [ ipv4 | ipv6 ]                     # IP version (default ipv4)
+  icmp | tcp | udp                    # IP protocol
+  --src x.x.x.x                       # Source IP address
+  --dst x.x.x.x                       # Destination IP address
+  --port N                            # Destination TCP or UDP port
+  --rate N                            # Packet rate in packets per second
+```
+
 ### `run`
 
-Request an OTG API endpoint to run OTG model.
+Request an OTG API endpoint to run OTG configuration.
 
 ```Shell
 otgen run 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ otgen create
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
-  --port N                            # Destination TCP or UDP port
+  [--sport N]                         # Source TCP or UDP port
+  [--dport N]                         # Destination TCP or UDP port
   [--count N]                         # Number of packets to transmit. Use 0 for continous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine.
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine.

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ Create a new OTG configuration item that can be further passed to stdin of `otge
 The `add` variant of the command first reads an OTG configuraton from stdin.
 
 ```Shell
-otgen create
-  [ flow ]                            # Create OTG flow configuration (default)
+otgen create flow                     # Create OTG flow configuration (default)
   [--name string]                     # Flow name (default f1)
   [--tx portname]                     # Test port name for TX (default p1) 
   [--rx portname]                     # Test port name for RX (default p2) 

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -25,31 +25,31 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create OTG configuration with the specified item",
+// addCmd represents the add command
+var addCmd = &cobra.Command{
+	Use:   "add",
+	Short: "Read OTG configuration from stdin and add the specified item",
 	Long: `
-Create OTG configuration with the specified item.
-The configuration can be passed to stdin of either "otgen run" or "otgen add" command.
+Read OTG configuration from stdin and add the specified item. 
+The output can be passed to stdin of "otgen run" or another "otgen add" command.
 
   For more information, go to https://github.com/open-traffic-generator/otgen
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Error("You must specify an OTG object to create, one from the set: flow")
+		log.Error("You must specify an OTG object to add, one from the set: flow")
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(createCmd)
+	rootCmd.AddCommand(addCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -22,7 +22,50 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/drone/envsubst"
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// Env vars for port locations
+	PORT_LOCATION_TEMPLATE = "${OTG_LOCATION_%NAME%}"
+	// Port location defaults
+	PORT_LOCATION_TX = "localhost:5555"
+	PORT_LOCATION_RX = "localhost:5556"
+	// Test port names
+	PORT_NAME_TX = "p1"
+	PORT_NAME_RX = "p2"
+	// OTG device names
+	DEVICE_NAME_1 = "otg1"
+	DEVICE_NAME_2 = "otg2"
+	// Env vars for MAC addresses
+	MAC_SRC_TX = "${OTG_FLOW_SMAC_P1}"
+	MAC_DST_TX = "${OTG_FLOW_DMAC_P1}"
+	MAC_SRC_RX = "${OTG_FLOW_SMAC_P2}"
+	MAC_DST_RX = "${OTG_FLOW_DMAC_P2}"
+	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
+	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
+	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
+	// Env vars for IPv4 addresses
+	IPV4_SRC = "${OTG_FLOW_SRC_IPV4}"
+	IPV4_DST = "${OTG_FLOW_DST_IPV4}"
+	// Default IPv4s are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
+	IPV4_DEFAULT_SRC = "192.0.2.1" // .1 == port  1
+	IPV4_DEFAULT_DST = "192.0.2.2" // .2 == port  2
+	// Env vars for IPv6 addresses
+	IPV6_SRC = "${OTG_FLOW_SRC_IPV6}"
+	IPV6_DST = "${OTG_FLOW_DST_IPV6}"
+	// Default IPv6s are link-local addresses based on default MAC addresses
+	IPV6_DEFAULT_SRC = "fe80::000:00ff:fe00:01aa"
+	IPV6_DEFAULT_DST = "fe80::000:00ff:fe00:02aa"
+	// Default device gateway and mask
+	IPV4_DEFAULT_GW     = "192.0.2.2"
+	IPV4_DEFAULT_PREFIX = 24
 )
 
 // createCmd represents the create command
@@ -52,4 +95,57 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func readOtgStdin(api gosnappi.GosnappiApi) gosnappi.Config {
+	otgbytes, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		log.Fatal(err)
+	}
+	otg := string(otgbytes)
+
+	config := api.NewConfig()
+	err = config.FromYaml(otg) // Thus YAML is assumed by default, and as a superset of JSON, it works for JSON format too
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return config
+}
+
+func otgGetOrCreatePort(config gosnappi.Config, name string, location string) gosnappi.Port {
+	for _, p := range config.Ports().Items() {
+		if p.Name() == name {
+			return p
+		}
+	}
+	p := config.Ports().Add().SetName(name)
+	p.SetLocation(location)
+	return p
+}
+
+func otgGetDevice(config gosnappi.Config, name string) gosnappi.Device {
+	for _, d := range config.Devices().Items() {
+		if d.Name() == name {
+			return d
+		}
+	}
+	return nil
+}
+
+// Substitute e with env variable of such name, if it is not empty, otherwise use default vaule d
+func envSubstOrDefault(e string, d string) string {
+	s, err := envsubst.EvalEnv(e)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if s == "" {
+		s = d
+	}
+	return s
+}
+
+// Produce a string from a "template" by replacing "%placeholder%" with "text"
+func stringFromTemplate(template string, placeholder string, text string) string {
+	return strings.Replace(template, "%"+placeholder+"%", text, -1)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,0 +1,55 @@
+/*
+Copyright © 2022 Open Traffic Generator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// createCmd represents the create command
+var createCmd = &cobra.Command{
+	Use:   "create",
+	Short: "Create OTG configuration that can be further passed to stdin of otgen run command",
+	Long: `Create OTG configuration that can be further passed to stdin of otgen run command.
+
+  For more information, go to https://github.com/open-traffic-generator/otgen
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("create called")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(createCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -29,7 +29,8 @@ import (
 var createCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create OTG configuration that can be further passed to stdin of otgen run command",
-	Long: `Create OTG configuration that can be further passed to stdin of otgen run command.
+	Long: `
+Create OTG configuration that can be further passed to stdin of otgen run command.
 
   For more information, go to https://github.com/open-traffic-generator/otgen
 `,

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -1,0 +1,152 @@
+/*
+Copyright © 2022 Open Traffic Generator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/spf13/cobra"
+)
+
+var deviceName string         // Device name
+var devicePort string         // Test port name
+var devicePortLocation string // Test port location string
+var deviceMac string          // Device ethernet MAC
+var deviceIPv4 string         // Device IPv4 address
+var deviceGWv4 string         // Device IPv4 default gateway
+var devicePrefixv4 int32      // Device IPv4 network prefix
+
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "New OTG device configuration",
+	Long: `
+New OTG device configuration.
+
+For more information, go to https://github.com/open-traffic-generator/otgen
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmd.Parent().Use == createCmd.Use {
+			createDevice()
+		} else {
+			addDevice()
+		}
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		// set default MACs depending on Tx test port
+		switch devicePort {
+		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly
+			if deviceMac == "" {
+				deviceMac = envSubstOrDefault(MAC_SRC_RX, MAC_DEFAULT_DST)
+			}
+		default: // PORT_NAME_TX
+			if deviceMac == "" {
+				deviceMac = envSubstOrDefault(MAC_SRC_TX, MAC_DEFAULT_SRC)
+			}
+		}
+
+		if devicePortLocation == "" {
+			devicePortLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)), PORT_LOCATION_TX)
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deviceCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deviceCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deviceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", DEVICE_NAME_1, "Device name") // TODO when creating multiple devices, iterrate for the next available device index
+
+	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_TX, "Test port name")
+	deviceCmd.Flags().StringVarP(&devicePortLocation, "location", "l", "", fmt.Sprintf("Test port location string (default \"%s\")", PORT_LOCATION_TX))
+
+	deviceCmd.Flags().StringVarP(&deviceMac, "mac", "M", "", fmt.Sprintf("Device MAC address (default \"%s\")", MAC_DEFAULT_SRC))
+	deviceCmd.Flags().StringVarP(&deviceIPv4, "ip", "I", IPV4_DEFAULT_SRC, "Device IP address") // TODO consider IP/prefix format: split(a, "/")
+	deviceCmd.Flags().StringVarP(&deviceGWv4, "gw", "G", IPV4_DEFAULT_GW, "Device default gateway")
+	deviceCmd.Flags().Int32VarP(&devicePrefixv4, "prefix", "P", IPV4_DEFAULT_PREFIX, "Device network prefix")
+
+	var deviceCmdCreateCopy = *deviceCmd
+	var deviceCmdAddCopy = *deviceCmd
+
+	createCmd.AddCommand(&deviceCmdCreateCopy)
+	addCmd.AddCommand(&deviceCmdAddCopy)
+
+}
+
+func createDevice() {
+	// Create a new API handle
+	api := gosnappi.NewApi()
+
+	// Create a flow
+	newDevice(api.NewConfig())
+}
+
+func addDevice() {
+	// Create a new API handle
+	api := gosnappi.NewApi()
+
+	// Read pre-existing traffic configuration from STDIN and then create a flow
+	newDevice(readOtgStdin(api))
+}
+
+func newDevice(config gosnappi.Config) {
+	// Add port locations to the configuration
+	otgGetOrCreatePort(config, devicePort, devicePortLocation)
+
+	// Device name
+	device := config.Devices().Add().SetName(deviceName)
+
+	// Device ethernets
+	deviceEth := device.Ethernets().Add().
+		SetName(deviceName + ".eth[0]").
+		SetMac(deviceMac)
+
+	// Connection is not yes available, tested with Ixia-c 0.0.1-3383
+	//deviceEth.Connection().SetPortName(devicePort)
+	deviceEth.SetPortName(devicePort)
+
+	deviceEth.Ipv4Addresses().Add().
+		SetName(deviceEth.Name() + ".ipv4[0]").
+		SetAddress(deviceIPv4).
+		SetGateway(deviceGWv4).
+		SetPrefix(devicePrefixv4)
+
+	// Print traffic configuration constructed
+	otgYaml, err := config.ToYaml()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(otgYaml)
+}

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -40,7 +40,8 @@ var chartType string   // type of chart to show
 var displayCmd = &cobra.Command{
 	Use:   "display",
 	Short: "Display running test metrics as a chart or a table",
-	Long: `Display running test metrics as a chart or a table.
+	Long: `
+Display running test metrics as a chart or a table.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -43,7 +43,10 @@ var flowFixedSize int32    // Frame size in bytes
 var flowCmd = &cobra.Command{
 	Use:   "flow",
 	Short: "Create OTG flow configuration",
-	Long: `Create OTG flow configuration.
+	Long: `
+Create OTG flow configuration.
+
+For more information, go to https://github.com/open-traffic-generator/otgen
 `,
 	Run: func(cmd *cobra.Command, args []string) {
 		createFlow()
@@ -77,7 +80,7 @@ func init() {
 	flowCmd.Flags().Int32VarP(&flowSrcPort, "sport", "", 0, "Source TCP/UDP port. If not specified, an incremental set of source ports would be used for each packet")
 	flowCmd.Flags().Int32VarP(&flowDstPort, "dport", "p", 7, "Destination TCP/UDP port")
 
-	flowCmd.Flags().Int64VarP(&flowRate, "rate", "r", 0, "Packet per second rate")
+	flowCmd.Flags().Int64VarP(&flowRate, "rate", "r", 0, "Packet per second rate. If not specified, default rate decision would be left to the traffic engine")
 
 	// We use 1000 as a default value for packet count instead of continous mode per OTG spec,
 	// as we want to prevent situations when unsuspecting user end up with non-stopping traffic

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -28,8 +28,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var flowSrc string // Source IP address
-var flowDst string // Destination IP address
+var flowSrcMac string // Source MAC address
+var flowDstMac string // Destination MAC address
+var flowSrc string    // Source IP address
+var flowDst string    // Destination IP address
 
 // flowCmd represents the flow command
 var flowCmd = &cobra.Command{
@@ -54,8 +56,14 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// flowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")
-	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address")
+
+	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
+	flowCmd.Flags().StringVarP(&flowSrcMac, "smac", "S", "02:00:00:00:01:aa", "Source MAC address")      // 01 == port 1, aa == otg side (bb == dut side)
+	flowCmd.Flags().StringVarP(&flowDstMac, "dmac", "D", "02:00:00:00:02:aa", "Destination MAC address") // 02 == port 2, aa == otg side (bb == dut side)
+
+	// Default IPs are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
+	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")      // .1 == port  1
+	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address") // .2 == port  2
 }
 
 func createFlow() {
@@ -88,8 +96,8 @@ func createFlow() {
 	ipv4 := pkt.Add().Ipv4()
 	tcp := pkt.Add().Tcp()
 
-	eth.Dst().SetValue("00:11:22:33:44:55")
-	eth.Src().SetValue("00:11:22:33:44:66")
+	eth.Src().SetValue(flowSrcMac)
+	eth.Dst().SetValue(flowDstMac)
 
 	ipv4.Src().SetValue(flowSrc)
 	ipv4.Dst().SetValue(flowDst)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -39,9 +39,15 @@ const (
 	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
 	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
 	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
+	// Env vars for IPv4 addresses
+	IPV4_SRC = "${OTG_FLOW_SRC_IPV4}"
+	IPV4_DST = "${OTG_FLOW_DST_IPV4}"
 	// Default IPv4s are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
 	IPV4_DEFAULT_SRC = "192.0.2.1" // .1 == port  1
 	IPV4_DEFAULT_DST = "192.0.2.2" // .2 == port  2
+	// Env vars for IPv6 addresses
+	IPV6_SRC = "${OTG_FLOW_SRC_IPV6}"
+	IPV6_DST = "${OTG_FLOW_DST_IPV6}"
 	// Default IPv6s are link-local addresses based on default MAC addresses
 	IPV6_DEFAULT_SRC = "fe80::000:00ff:fe00:01aa"
 	IPV6_DEFAULT_DST = "fe80::000:00ff:fe00:02aa"
@@ -88,11 +94,11 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		if flowIPv6 {
 			flowIPv4 = false
-			if flowSrc == IPV4_DEFAULT_SRC {
-				flowSrc = IPV6_DEFAULT_SRC
+			if flowSrc == envSubstOrDefault(IPV4_SRC, IPV4_DEFAULT_SRC) {
+				flowSrc = envSubstOrDefault(IPV6_SRC, IPV6_DEFAULT_SRC)
 			}
-			if flowDst == IPV4_DEFAULT_DST {
-				flowDst = IPV6_DEFAULT_DST
+			if flowDst == envSubstOrDefault(IPV4_DST, IPV4_DEFAULT_DST) {
+				flowDst = envSubstOrDefault(IPV6_DST, IPV6_DEFAULT_DST)
 			}
 		}
 		switch flowProto {
@@ -143,8 +149,8 @@ func init() {
 	flowCmd.Flags().BoolVarP(&flowIPv6, "ipv6", "6", false, "IP Version 6")
 	flowCmd.MarkFlagsMutuallyExclusive("ipv4", "ipv6")
 
-	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", IPV4_DEFAULT_SRC, "Source IP address")
-	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", IPV4_DEFAULT_DST, "Destination IP address")
+	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", envSubstOrDefault(IPV4_SRC, IPV4_DEFAULT_SRC), "Source IP address")
+	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", envSubstOrDefault(IPV4_DST, IPV4_DEFAULT_DST), "Destination IP address")
 
 	// Transport protocol
 	flowCmd.Flags().StringVarP(&flowProto, "proto", "P", PROTO_TCP, "IP transport protocol: \"icmp\" | \"tcp\" | \"udp\"")

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -32,6 +32,8 @@ var flowSrcMac string      // Source MAC address
 var flowDstMac string      // Destination MAC address
 var flowSrc string         // Source IP address
 var flowDst string         // Destination IP address
+var flowSrcPort int32      // Source TCP/UDP port
+var flowDstPort int32      // Destination TCP/UDP port
 var flowRate int64         // Packet per second rate
 var flowFixedPackets int32 // Number of packets to transmit
 var flowFixedSize int32    // Frame size in bytes
@@ -67,6 +69,9 @@ func init() {
 	// Default IPs are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
 	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")      // .1 == port  1
 	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address") // .2 == port  2
+
+	flowCmd.Flags().Int32VarP(&flowSrcPort, "sport", "", 0, "Source TCP/UDP port")
+	flowCmd.Flags().Int32VarP(&flowDstPort, "dport", "p", 0, "Destination TCP/UDP port")
 
 	flowCmd.Flags().Int64VarP(&flowRate, "rate", "r", 0, "Packet per second rate")
 
@@ -119,8 +124,12 @@ func createFlow() {
 	ipv4.Src().SetValue(flowSrc)
 	ipv4.Dst().SetValue(flowDst)
 
-	tcp.SrcPort().SetValue(5000)
-	tcp.DstPort().SetValue(6000)
+	if flowSrcPort >= 0 {
+		tcp.SrcPort().SetValue(flowSrcPort)
+	}
+	if flowDstPort >= 0 {
+		tcp.DstPort().SetValue(flowDstPort)
+	}
 
 	// Print traffic configuration constructed
 	otgYaml, err := config.ToYaml()

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -22,32 +22,32 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
-// createCmd represents the create command
-var createCmd = &cobra.Command{
-	Use:   "create",
-	Short: "Create OTG configuration that can be further passed to stdin of otgen run command",
-	Long: `Create OTG configuration that can be further passed to stdin of otgen run command.
-
-  For more information, go to https://github.com/open-traffic-generator/otgen
+// flowCmd represents the flow command
+var flowCmd = &cobra.Command{
+	Use:   "flow",
+	Short: "Create OTG flow configuration",
+	Long: `Create OTG flow configuration.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Error("You must specify an OTG object to create, one from the set: flow")
+		fmt.Println("flow called")
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(createCmd)
+	createCmd.AddCommand(flowCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// createCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// flowCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// flowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -32,6 +32,7 @@ var flowSrcMac string      // Source MAC address
 var flowDstMac string      // Destination MAC address
 var flowSrc string         // Source IP address
 var flowDst string         // Destination IP address
+var flowProto string       // IP transport protocol
 var flowSrcPort int32      // Source TCP/UDP port
 var flowDstPort int32      // Destination TCP/UDP port
 var flowRate int64         // Packet per second rate
@@ -69,6 +70,9 @@ func init() {
 	// Default IPs are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
 	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")      // .1 == port  1
 	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address") // .2 == port  2
+
+	// Transport protocol
+	flowCmd.Flags().StringVarP(&flowProto, "proto", "P", "tcp", "IP transport protocol: tcp | udp")
 
 	flowCmd.Flags().Int32VarP(&flowSrcPort, "sport", "", 0, "Source TCP/UDP port. If not specified, an incremental set of source ports would be used for each packet")
 	flowCmd.Flags().Int32VarP(&flowDstPort, "dport", "p", 7, "Destination TCP/UDP port")
@@ -115,23 +119,38 @@ func createFlow() {
 	// Configure the header stack
 	pkt := flow.Packet()
 	eth := pkt.Add().Ethernet()
-	ipv4 := pkt.Add().Ipv4()
-	tcp := pkt.Add().Tcp()
-
 	eth.Src().SetValue(flowSrcMac)
 	eth.Dst().SetValue(flowDstMac)
 
+	ipv4 := pkt.Add().Ipv4()
 	ipv4.Src().SetValue(flowSrc)
 	ipv4.Dst().SetValue(flowDst)
 
-	if flowSrcPort > 0 {
-		tcp.SrcPort().SetValue(flowSrcPort)
-	} else if flowSrcPort == 0 {
-		// no source port was specified, use incrementing ports
-		tcp.SrcPort().Increment().SetStart(1024).SetStep(7).SetCount(65535 - 1024)
-	}
-	if flowDstPort > 0 {
-		tcp.DstPort().SetValue(flowDstPort)
+	switch flowProto {
+	case "tcp":
+		tcp := pkt.Add().Tcp()
+		if flowSrcPort > 0 {
+			tcp.SrcPort().SetValue(flowSrcPort)
+		} else if flowSrcPort == 0 {
+			// no source port was specified, use incrementing ports
+			tcp.SrcPort().Increment().SetStart(1024).SetStep(7).SetCount(65535 - 1024)
+		}
+		if flowDstPort > 0 {
+			tcp.DstPort().SetValue(flowDstPort)
+		}
+	case "udp":
+		udp := pkt.Add().Udp()
+		if flowSrcPort > 0 {
+			udp.SrcPort().SetValue(flowSrcPort)
+		} else if flowSrcPort == 0 {
+			// no source port was specified, use incrementing ports
+			udp.SrcPort().Increment().SetStart(1024).SetStep(7).SetCount(65535 - 1024)
+		}
+		if flowDstPort > 0 {
+			udp.DstPort().SetValue(flowDstPort)
+		}
+	default:
+		log.Fatalf("Unsupported transport protocol: %s", flowProto)
 	}
 
 	// Print traffic configuration constructed

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -92,6 +92,10 @@ func createFlow() {
 	tcp.SrcPort().SetValue(5000)
 	tcp.DstPort().SetValue(6000)
 
-	// Push traffic configuration constructed so far to traffic generator
-	fmt.Println(config.ToYaml())
+	// Print traffic configuration constructed
+	otgYaml, err := config.ToYaml()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(otgYaml)
 }

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -28,6 +28,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flowName string        // Flow name
 var flowSrcMac string      // Source MAC address
 var flowDstMac string      // Destination MAC address
 var flowSrc string         // Source IP address
@@ -66,6 +67,8 @@ func init() {
 	// is called directly, e.g.:
 	// flowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
+	flowCmd.Flags().StringVarP(&flowName, "name", "n", "f1", "Flow name") // TODO when creating multiple flows, iterrate for the next available flow index
+
 	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
 	flowCmd.Flags().StringVarP(&flowSrcMac, "smac", "S", "02:00:00:00:01:aa", "Source MAC address")      // 01 == port 1, aa == otg side (bb == dut side)
 	flowCmd.Flags().StringVarP(&flowDstMac, "dmac", "D", "02:00:00:00:02:aa", "Destination MAC address") // 02 == port 2, aa == otg side (bb == dut side)
@@ -101,7 +104,7 @@ func createFlow() {
 	p2 := config.Ports().Add().SetName("p2").SetLocation("${OTG_P2_LOCATION}")
 
 	// Configure the flow and set the endpoints
-	flow := config.Flows().Add().SetName("f1")
+	flow := config.Flows().Add().SetName(flowName)
 	flow.TxRx().Port().SetTxName(p1.Name())
 	flow.TxRx().Port().SetRxName(p2.Name())
 

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -28,6 +28,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var flowSrc string // Source IP address
+var flowDst string // Destination IP address
+
 // flowCmd represents the flow command
 var flowCmd = &cobra.Command{
 	Use:   "flow",
@@ -51,6 +54,8 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// flowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")
+	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address")
 }
 
 func createFlow() {
@@ -86,8 +91,8 @@ func createFlow() {
 	eth.Dst().SetValue("00:11:22:33:44:55")
 	eth.Src().SetValue("00:11:22:33:44:66")
 
-	ipv4.Src().SetValue("10.1.1.1")
-	ipv4.Dst().SetValue("20.1.1.1")
+	ipv4.Src().SetValue(flowSrc)
+	ipv4.Dst().SetValue(flowDst)
 
 	tcp.SrcPort().SetValue(5000)
 	tcp.DstPort().SetValue(6000)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -70,8 +70,8 @@ func init() {
 	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")      // .1 == port  1
 	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address") // .2 == port  2
 
-	flowCmd.Flags().Int32VarP(&flowSrcPort, "sport", "", 0, "Source TCP/UDP port")
-	flowCmd.Flags().Int32VarP(&flowDstPort, "dport", "p", 0, "Destination TCP/UDP port")
+	flowCmd.Flags().Int32VarP(&flowSrcPort, "sport", "", 0, "Source TCP/UDP port. If not specified, an incremental set of source ports would be used for each packet")
+	flowCmd.Flags().Int32VarP(&flowDstPort, "dport", "p", 7, "Destination TCP/UDP port")
 
 	flowCmd.Flags().Int64VarP(&flowRate, "rate", "r", 0, "Packet per second rate")
 
@@ -124,10 +124,13 @@ func createFlow() {
 	ipv4.Src().SetValue(flowSrc)
 	ipv4.Dst().SetValue(flowDst)
 
-	if flowSrcPort >= 0 {
+	if flowSrcPort > 0 {
 		tcp.SrcPort().SetValue(flowSrcPort)
+	} else if flowSrcPort == 0 {
+		// no source port was specified, use incrementing ports
+		tcp.SrcPort().Increment().SetStart(1024).SetStep(7).SetCount(65535 - 1024)
 	}
-	if flowDstPort >= 0 {
+	if flowDstPort > 0 {
 		tcp.DstPort().SetValue(flowDstPort)
 	}
 

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -34,6 +34,7 @@ var flowSrc string         // Source IP address
 var flowDst string         // Destination IP address
 var flowRate int64         // Packet per second rate
 var flowFixedPackets int32 // Number of packets to transmit
+var flowFixedSize int32    // Frame size in bytes
 
 // flowCmd represents the flow command
 var flowCmd = &cobra.Command{
@@ -72,7 +73,8 @@ func init() {
 	// We use 1000 as a default value for packet count instead of continous mode per OTG spec,
 	// as we want to prevent situations when unsuspecting user end up with non-stopping traffic
 	// if no parameter was specified
-	flowCmd.Flags().Int32VarP(&flowFixedPackets, "count", "c", 1000, "Number of packets to transmit. Use 0 for continous mode.")
+	flowCmd.Flags().Int32VarP(&flowFixedPackets, "count", "c", 1000, "Number of packets to transmit. Use 0 for continous mode")
+	flowCmd.Flags().Int32VarP(&flowFixedSize, "size", "", 0, "Frame size in bytes. If not specified, the minimum supported by the traffic engine will be used")
 }
 
 func createFlow() {
@@ -92,7 +94,9 @@ func createFlow() {
 	flow.TxRx().Port().SetRxName(p2.Name())
 
 	// Configure the size of a packet and the number of packets to transmit
-	flow.Size().SetFixed(128)
+	if flowFixedSize > 0 {
+		flow.Size().SetFixed(flowFixedSize)
+	}
 	if flowFixedPackets > 0 { // If set to 0, no duration would be specified. According to OTG spec, continous mode would be used
 		flow.Duration().FixedPackets().SetPackets(flowFixedPackets)
 	}

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -24,11 +24,15 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/drone/envsubst"
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
 )
 
 const (
+	// Env vars for port locations
+	PORT_LOCATION_P1 = "${OTG_LOCATION_P1}"
+	PORT_LOCATION_P2 = "${OTG_LOCATION_P2}"
 	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
 	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
 	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
@@ -169,8 +173,22 @@ func createFlow() {
 	config := api.NewConfig()
 
 	// Add port locations to the configuration
-	p1 := config.Ports().Add().SetName("p1").SetLocation("${OTG_P1_LOCATION}")
-	p2 := config.Ports().Add().SetName("p2").SetLocation("${OTG_P2_LOCATION}")
+	p1str, err := envsubst.EvalEnv(PORT_LOCATION_P1)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if p1str == "" {
+		p1str = PORT_LOCATION_P1
+	}
+	p1 := config.Ports().Add().SetName("p1").SetLocation(p1str)
+	p2str, err := envsubst.EvalEnv(PORT_LOCATION_P2)
+	if err != nil {
+		log.Fatal(err)
+	}
+	if p2str == "" {
+		p2str = PORT_LOCATION_P2
+	}
+	p2 := config.Ports().Add().SetName("p2").SetLocation(p2str)
 
 	// Configure the flow and set the endpoints
 	flow := config.Flows().Add().SetName(flowName)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -32,6 +32,7 @@ var flowSrcMac string // Source MAC address
 var flowDstMac string // Destination MAC address
 var flowSrc string    // Source IP address
 var flowDst string    // Destination IP address
+var flowRate int64    // Packet per second rate
 
 // flowCmd represents the flow command
 var flowCmd = &cobra.Command{
@@ -64,6 +65,8 @@ func init() {
 	// Default IPs are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
 	flowCmd.Flags().StringVarP(&flowSrc, "src", "s", "192.0.2.1", "Source IP address")      // .1 == port  1
 	flowCmd.Flags().StringVarP(&flowDst, "dst", "d", "192.0.2.2", "Destination IP address") // .2 == port  2
+
+	flowCmd.Flags().Int64VarP(&flowRate, "rate", "r", 0, "Packet per second rate")
 }
 
 func createFlow() {
@@ -85,7 +88,9 @@ func createFlow() {
 	// Configure the size of a packet and the number of packets to transmit
 	flow.Size().SetFixed(128)
 	flow.Duration().FixedPackets().SetPackets(1000)
-	flow.Rate().SetPps(100)
+	if flowRate > 0 {
+		flow.Rate().SetPps(flowRate)
+	}
 
 	// Configure flow metric collection
 	flow.Metrics().SetEnable(true)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +35,7 @@ var flowCmd = &cobra.Command{
 	Long: `Create OTG flow configuration.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("flow called")
+		createFlow()
 	},
 }
 
@@ -50,4 +51,47 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// flowCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func createFlow() {
+	// Create a new API handle to make API calls against a traffic generator
+	api := gosnappi.NewApi()
+
+	// Create a new traffic configuration that will be set on traffic generator
+	config := api.NewConfig()
+
+	// Add port locations to the configuration
+	p1 := config.Ports().Add().SetName("p1").SetLocation("${OTG_P1_LOCATION}")
+	p2 := config.Ports().Add().SetName("p2").SetLocation("${OTG_P2_LOCATION}")
+
+	// Configure the flow and set the endpoints
+	flow := config.Flows().Add().SetName("f1")
+	flow.TxRx().Port().SetTxName(p1.Name())
+	flow.TxRx().Port().SetRxName(p2.Name())
+
+	// Configure the size of a packet and the number of packets to transmit
+	flow.Size().SetFixed(128)
+	flow.Duration().FixedPackets().SetPackets(1000)
+	flow.Rate().SetPps(100)
+
+	// Configure flow metric collection
+	flow.Metrics().SetEnable(true)
+
+	// Configure the header stack
+	pkt := flow.Packet()
+	eth := pkt.Add().Ethernet()
+	ipv4 := pkt.Add().Ipv4()
+	tcp := pkt.Add().Tcp()
+
+	eth.Dst().SetValue("00:11:22:33:44:55")
+	eth.Src().SetValue("00:11:22:33:44:66")
+
+	ipv4.Src().SetValue("10.1.1.1")
+	ipv4.Dst().SetValue("20.1.1.1")
+
+	tcp.SrcPort().SetValue(5000)
+	tcp.DstPort().SetValue(6000)
+
+	// Push traffic configuration constructed so far to traffic generator
+	fmt.Println(config.ToYaml())
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,7 +35,8 @@ var log = logrus.New()
 var rootCmd = &cobra.Command{
 	Use:   "otgen",
 	Short: "Open Traffic Generator CLI Tool",
-	Long: `Open Traffic Generator CLI Tool.
+	Long: `
+Open Traffic Generator CLI Tool.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,8 +24,12 @@ package cmd
 import (
 	"os"
 
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
+
+// Create a new instance of the logger
+var log = logrus.New()
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -46,7 +46,8 @@ var xeta = float32(0.0)           // How long to wait before forcing traffic to 
 var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Request an OTG API endpoint to run OTG model",
-	Long: `Request an OTG API endpoint to run OTG model.
+	Long: `
+Request an OTG API endpoint to run OTG model.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -42,9 +41,6 @@ var otgMetrics string             // Metrics type to report: "port" for PortMetr
 var otgPullIntervalStr string     // Interval to pull OTG metrics. Example: 1s (default 500ms)
 var otgPullInterval time.Duration // Parsed interval to pull OTG metrics
 var xeta = float32(0.0)           // How long to wait before forcing traffic to stop. In multiples of ETA
-
-// Create a new instance of the logger
-var log = logrus.New()
 
 // runCmd represents the run command
 var runCmd = &cobra.Command{

--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -51,7 +51,9 @@ var transformTemplateFile string // Go template file for transform
 var transformCmd = &cobra.Command{
 	Use:   "transform",
 	Short: "Transform raw OTG metrics into a format suitable for further processing",
-	Long: `Transform raw OTG metrics into a format suitable for further processing.
+	Long: `
+Transform raw OTG metrics into a format suitable for further processing.
+
 If no parameters is provided, transform validates input for a match with
 OTG MetricsResponse data structure, and if matched, outputs it as is.
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/open-traffic-generator/otgen
 go 1.17
 
 require (
+	github.com/gosuri/uilive v0.0.4
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.17.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/open-traffic-generator/snappi/gosnappi v0.7.18
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0
@@ -18,12 +20,10 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
-	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
-	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.17.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/open-traffic-generator/snappi/gosnappi v0.7.18
+	github.com/open-traffic-generator/snappi/gosnappi v0.8.8
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.5.0
-	google.golang.org/protobuf v1.28.0
+	google.golang.org/protobuf v1.28.1
 )
 
 require (
@@ -19,21 +19,18 @@ require (
 	github.com/ghodss/yaml v1.0.0 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/go-cmp v0.5.8 // indirect
-	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
-	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/net v0.0.0-20220526153639-5463443f8c37 // indirect
 	golang.org/x/sys v0.0.0-20220704084225-05e143d24a9e // indirect
 	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/genproto v0.0.0-20220527130721-00d5c0f3be58 // indirect
-	google.golang.org/grpc v1.47.0 // indirect
+	google.golang.org/grpc v1.48.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/open-traffic-generator/otgen
 go 1.17
 
 require (
+	github.com/drone/envsubst v1.0.3
 	github.com/gosuri/uilive v0.0.4
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.17.0

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/mum4k/termdash v0.17.0/go.mod h1:inGde56cgA4QXe1Sb3eQIJQnN5CLDsmDjzda
 github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/open-traffic-generator/snappi/gosnappi v0.7.18 h1:RCyCtbvc6Qx11vp0Ec3BxZ76xcOMAzPTzrh6Y9Fywr4=
-github.com/open-traffic-generator/snappi/gosnappi v0.7.18/go.mod h1:yy1mdBicujeM24qLEEz+DDqCazoeg4yXTJjOKeiSUr4=
+github.com/open-traffic-generator/snappi/gosnappi v0.8.8 h1:nHosWx6S9zXG18fNjR24IUiTypPBGZDgGfo2wTMhuDc=
+github.com/open-traffic-generator/snappi/gosnappi v0.8.8/go.mod h1:RF/I/bClukYEyNQ2jyeAMgVbU/rYWU1sBznGXBiXwD8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
@@ -97,11 +97,13 @@ github.com/spf13/cobra v1.5.0/go.mod h1:dWXEIy2H428czQCjInthrTRUg7yKbok+2Qi/yBIJ
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -174,8 +176,8 @@ google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.36.0/go.mod h1:qjiiYl8FncCW8feJPdyg3v6XW24KsRHe+dy9BAGRRjU=
 google.golang.org/grpc v1.46.2/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
-google.golang.org/grpc v1.47.0 h1:9n77onPX5F3qfFCqjy9dhn8PbNQsIKeVU04J9G7umt8=
-google.golang.org/grpc v1.47.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
+google.golang.org/grpc v1.48.0 h1:rQOsyJ/8+ufEDJd/Gdsz7HG220Mh9HAhFHRGnIjda0w=
+google.golang.org/grpc v1.48.0/go.mod h1:vN9eftEi1UMyUsIF80+uQXhHjbXYbm0uXoFCACuMGWk=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -188,8 +190,9 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.0 h1:w43yiav+6bVFTBQFZX0r7ipe9JQ1QsbMgHwbBziscLw=
 google.golang.org/protobuf v1.28.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
+google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
+github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
### `create` and `add`

Create a new OTG configuration item that can be further passed to stdin of `otgen run` command.
The `add` variant of the command first reads an OTG configuration from stdin.

```Shell
otgen create flow                     # Create OTG flow configuration (default)
  [--name string]                     # Flow name (default f1)
  [--tx portname]                     # Test port name for TX (default p1) 
  [--rx portname]                     # Test port name for RX (default p2) 
  [--ipv4 ]                           # IP version 4 (default)
  [--ipv6 ]                           # IP version 6
  [--proto icmp | tcp | udp]          # IP transport protocol
  [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
  [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address
  [--src x.x.x.x]                     # Source IP address
  [--dst x.x.x.x]                     # Destination IP address
  [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet
  [--dport N]                         # Destination TCP or UDP port (default 7 - echo protocol)
  [--count N]                         # Number of packets to transmit. Use 0 for continuous mode. (default 1000)
  [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
  [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine
  [--loss]                            # Enable loss metrics
  [--latency sf | ct]                 # Enable latency metrics: sf for store_forward | ct for cut_through
  [--timestamps]                      # Enable metrics timestamps
  [--nometrics ]                      # Disable flow metrics
```

## Environmental variables

Use env variables to define values of the following OTG attributes:

```Shell
OTG_LOCATION_P1                       # location for test port "p1"
OTG_LOCATION_P2                       # location for test port "p2"

OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
OTG_FLOW_SMAC_P2                      # Source MAC address to use for flows with Tx on port "p2"
OTG_FLOW_DMAC_P2                      # Destination MAC address to use for flows with Tx on port "p2"

OTG_FLOW_SRC_IPV4                     # Source IPv4 address to use for flows
OTG_FLOW_DST_IPV4                     # Destination IPv4 address to use for flows
OTG_FLOW_SRC_IPV6                     # Source IPv6 address to use for flows
OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flows
```

