### PR TITLE
`device` functionality added to `create` and `add` commands

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -20,6 +20,7 @@ cobra-cli add display --license mit --author "Open Traffic Generator"
 cobra-cli add create --license mit --author "Open Traffic Generator"
 cobra-cli add add --license mit --author "Open Traffic Generator"
 cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create and add
+cobra-cli add device --license mit --author "Open Traffic Generator" # subcommand for create and add
 ````
 
 ### GoReleaser

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ otgen create device                   # Create OTG device configuration
   [--tx portname]                     # Test port name for TX (default p1) 
   [--rx portname]                     # Test port name for RX (default p2) 
   [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
+  [--ip x.x.x.x]                      # Device IP address
+  [--gw x.x.x.x]                      # Device default gateway
+  [--prefix nn]                       # Device network prefix
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ````
 
-Port locations are read from `ENV:OTG_LOCATION_P1` and `ENV:OTG_LOCATION_P2`.
+Port locations are read from `ENV:OTG_LOCATION_%PORT_NAME%` where `%PORT_NAME%` is replaced by name of the test port provided via `--tx | --rx`.
 
 See [Environmental variables](#environmental-variables) section for more options.
 
@@ -135,6 +135,7 @@ For such parameters it may be more convinient to change default values used by `
 Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
 
 ```Shell
+OTG_LOCATION_%PORT_NAME%              # location for test port with a name PORT_NAME, for example:
 OTG_LOCATION_P1                       # location for test port "p1"
 OTG_LOCATION_P2                       # location for test port "p2"
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ otgen create flow                     # Create OTG flow configuration
   [--dst x.x.x.x]                     # Destination IP address
   [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet
   [--dport N]                         # Destination TCP or UDP port (default 7 - echo protocol)
+  [--swap]                            # Swap default values of: Tx and Rx names and locations; source and destination MACs, IPs and TCP/UDP ports
   [--count N]                         # Number of packets to transmit. Use 0 for continuous mode. (default 1000)
   [--rate N]                          # Packet rate in packets per second. If not specified, default rate decision would be left to the traffic engine
   [--size N]                          # Frame size in bytes. If not specified, default frame size decision would be left to the traffic engine

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ````
 
-Port locations are read from `ENV:OTG_LOCATION_%PORT_NAME%` where `%PORT_NAME%` is replaced by name of the test port provided via `--tx | --rx`.
-
-See [Environmental variables](#environmental-variables) section for more options.
-
 ## Command reference
 
 ### `create` and `add`
@@ -32,8 +28,10 @@ The `add` variant of the command first reads an OTG configuration from stdin.
 ```Shell
 otgen create flow                     # Create OTG flow configuration
   [--name string]                     # Flow name (default f1)
-  [--tx portname]                     # Test port name for TX (default p1) 
-  [--rx portname]                     # Test port name for RX (default p2) 
+  [--tx string]                       # Test port name for TX (default p1) 
+  [--rx string]                       # Test port name for RX (default p2) 
+  [--txl string]                      # Test port location string for TX (default localhost:5555) 
+  [--rxl string]                      # Test port location string for RX (default localhost:5556) 
   [--ipv4 ]                           # IP version 4 (default)
   [--ipv6 ]                           # IP version 6
   [--proto icmp | tcp | udp]          # IP transport protocol
@@ -55,7 +53,8 @@ otgen create flow                     # Create OTG flow configuration
 ```Shell
 otgen create device                   # Create OTG device configuration
   [--name string]                     # Device name (default otg1)
-  [--port portname]                   # Test port name (default p1) 
+  [--port string]                     # Test port name (default p1)
+  [--location string]                 # Test port location string (default localhost:5555)
   [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
   [--ip x.x.x.x]                      # Device IP address
   [--gw x.x.x.x]                      # Device default gateway
@@ -136,8 +135,6 @@ Environmental variables is one of the mechanisms used by `otgen` to control defa
 
 ```Shell
 OTG_LOCATION_%PORT_NAME%              # location for test port with a name PORT_NAME, for example:
-OTG_LOCATION_P1                       # location for test port "p1"
-OTG_LOCATION_P2                       # location for test port "p2"
 
 OTG_FLOW_SMAC_P1                      # Source MAC address to use for flows with Tx on port "p1"
 OTG_FLOW_DMAC_P1                      # Destination MAC address to use for flows with Tx on port "p1"
@@ -165,4 +162,4 @@ export OTG_FLOW_SRC_IPV6="fe80::000:00ff:fe00:01aa"
 export OTG_FLOW_DST_IPV6="fe80::000:00ff:fe00:02aa"
 ```
 
-Note, default values displayed via built-in `--help` output reflect currently set environmental variables values.
+Note, default values displayed via built-in `--help` output reflect currently set environmental variables values, except for test port location strings.

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create a new OTG configuration item that can be further passed to stdin of `otge
 The `add` variant of the command first reads an OTG configuration from stdin.
 
 ```Shell
-otgen create flow                     # Create OTG flow configuration (default)
+otgen create flow                     # Create OTG flow configuration
   [--name string]                     # Flow name (default f1)
   [--tx portname]                     # Test port name for TX (default p1) 
   [--rx portname]                     # Test port name for RX (default p2) 
@@ -51,6 +51,12 @@ otgen create flow                     # Create OTG flow configuration (default)
   [--timestamps]                      # Enable metrics timestamps
   [--nometrics ]                      # Disable flow metrics
 ```
+
+```Shell
+otgen create device                   # Create OTG device configuration
+  [--name string]                     # Device name (default otg1)
+```
+
 
 ### `run`
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ otgen create flow                     # Create OTG flow configuration
 ```Shell
 otgen create device                   # Create OTG device configuration
   [--name string]                     # Device name (default otg1)
+  [--tx portname]                     # Test port name for TX (default p1) 
+  [--rx portname]                     # Test port name for RX (default p2) 
+  [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -55,8 +55,7 @@ otgen create flow                     # Create OTG flow configuration
 ```Shell
 otgen create device                   # Create OTG device configuration
   [--name string]                     # Device name (default otg1)
-  [--tx portname]                     # Test port name for TX (default p1) 
-  [--rx portname]                     # Test port name for RX (default p2) 
+  [--port portname]                   # Test port name (default p1) 
   [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
   [--ip x.x.x.x]                      # Device IP address
   [--gw x.x.x.x]                      # Device default gateway

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -34,6 +34,9 @@ import (
 const (
 	// Env vars for port locations
 	PORT_LOCATION_TEMPLATE = "${OTG_LOCATION_%NAME%}"
+	// Port location defaults
+	PORT_LOCATION_TX = "localhost:5555"
+	PORT_LOCATION_RX = "localhost:5556"
 	// Test port names
 	PORT_NAME_P1 = "p1"
 	PORT_NAME_P2 = "p2"
@@ -135,7 +138,7 @@ func otgGetOrCreatePort(config gosnappi.Config, name string, location string) go
 		}
 	}
 	p := config.Ports().Add().SetName(name)
-	p.SetLocation(envSubstOrDefault(location, location))
+	p.SetLocation(location)
 	return p
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -38,8 +38,8 @@ const (
 	PORT_LOCATION_TX = "localhost:5555"
 	PORT_LOCATION_RX = "localhost:5556"
 	// Test port names
-	PORT_NAME_P1 = "p1"
-	PORT_NAME_P2 = "p2"
+	PORT_NAME_TX = "p1"
+	PORT_NAME_RX = "p2"
 	// OTG device names
 	DEVICE_NAME_1 = "otg1"
 	DEVICE_NAME_2 = "otg2"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -22,7 +22,25 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
+)
+
+const (
+	// Env vars for port locations
+	PORT_LOCATION_P1 = "${OTG_LOCATION_P1}"
+	PORT_LOCATION_P2 = "${OTG_LOCATION_P2}"
+	// Test port names
+	PORT_NAME_P1 = "p1"
+	PORT_NAME_P2 = "p2"
+	// Env vars for MAC addresses
+	MAC_SRC_P1 = "${OTG_FLOW_SMAC_P1}"
+	MAC_DST_P1 = "${OTG_FLOW_DMAC_P1}"
+	MAC_SRC_P2 = "${OTG_FLOW_SMAC_P2}"
+	MAC_DST_P2 = "${OTG_FLOW_DMAC_P2}"
+	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
+	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
+	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
 )
 
 // createCmd represents the create command
@@ -52,4 +70,13 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// createCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func otgConfigHasPort(config gosnappi.Config, name string) bool {
+	for _, p := range config.Ports().Items() {
+		if p.Name() == name {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"io"
 	"os"
+	"strings"
 
 	"github.com/drone/envsubst"
 	"github.com/open-traffic-generator/snappi/gosnappi"
@@ -32,8 +33,7 @@ import (
 
 const (
 	// Env vars for port locations
-	PORT_LOCATION_P1 = "${OTG_LOCATION_P1}"
-	PORT_LOCATION_P2 = "${OTG_LOCATION_P2}"
+	PORT_LOCATION_TEMPLATE = "${OTG_LOCATION_%NAME%}"
 	// Test port names
 	PORT_NAME_P1 = "p1"
 	PORT_NAME_P2 = "p2"
@@ -158,4 +158,9 @@ func envSubstOrDefault(e string, d string) string {
 		s = d
 	}
 	return s
+}
+
+// Produce a string from a "template" by replacing "%placeholder%" with "text"
+func stringFromTemplate(template string, placeholder string, text string) string {
+	return strings.Replace(template, "%"+placeholder+"%", text, -1)
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -44,10 +44,10 @@ const (
 	DEVICE_NAME_1 = "otg1"
 	DEVICE_NAME_2 = "otg2"
 	// Env vars for MAC addresses
-	MAC_SRC_P1 = "${OTG_FLOW_SMAC_P1}"
-	MAC_DST_P1 = "${OTG_FLOW_DMAC_P1}"
-	MAC_SRC_P2 = "${OTG_FLOW_SMAC_P2}"
-	MAC_DST_P2 = "${OTG_FLOW_DMAC_P2}"
+	MAC_SRC_TX = "${OTG_FLOW_SMAC_P1}"
+	MAC_DST_TX = "${OTG_FLOW_DMAC_P1}"
+	MAC_SRC_RX = "${OTG_FLOW_SMAC_P2}"
+	MAC_DST_RX = "${OTG_FLOW_DMAC_P2}"
 	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
 	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
 	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -119,6 +119,15 @@ func otgConfigHasPort(config gosnappi.Config, name string) bool {
 	return false
 }
 
+func otgGetPort(config gosnappi.Config, name string) gosnappi.Port {
+	for _, p := range config.Ports().Items() {
+		if p.Name() == name {
+			return p
+		}
+	}
+	return nil
+}
+
 func otgGetOrCreatePort(config gosnappi.Config, name string, location string) gosnappi.Port {
 	for _, p := range config.Ports().Items() {
 		if p.Name() == name {
@@ -128,6 +137,15 @@ func otgGetOrCreatePort(config gosnappi.Config, name string, location string) go
 	p := config.Ports().Add().SetName(name)
 	p.SetLocation(envSubstOrDefault(location, location))
 	return p
+}
+
+func otgGetDevice(config gosnappi.Config, name string) gosnappi.Device {
+	for _, d := range config.Devices().Items() {
+		if d.Name() == name {
+			return d
+		}
+	}
+	return nil
 }
 
 // Substitute e with env variable of such name, if it is not empty, otherwise use default vaule d

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -113,24 +113,6 @@ func readOtgStdin(api gosnappi.GosnappiApi) gosnappi.Config {
 	return config
 }
 
-func otgConfigHasPort(config gosnappi.Config, name string) bool {
-	for _, p := range config.Ports().Items() {
-		if p.Name() == name {
-			return true
-		}
-	}
-	return false
-}
-
-func otgGetPort(config gosnappi.Config, name string) gosnappi.Port {
-	for _, p := range config.Ports().Items() {
-		if p.Name() == name {
-			return p
-		}
-	}
-	return nil
-}
-
 func otgGetOrCreatePort(config gosnappi.Config, name string, location string) gosnappi.Port {
 	for _, p := range config.Ports().Items() {
 		if p.Name() == name {

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -37,6 +37,9 @@ const (
 	// Test port names
 	PORT_NAME_P1 = "p1"
 	PORT_NAME_P2 = "p2"
+	// OTG device names
+	DEVICE_NAME_1 = "otg1"
+	DEVICE_NAME_2 = "otg2"
 	// Env vars for MAC addresses
 	MAC_SRC_P1 = "${OTG_FLOW_SMAC_P1}"
 	MAC_DST_P1 = "${OTG_FLOW_DMAC_P1}"

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -45,6 +45,21 @@ const (
 	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
 	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
 	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
+	// Env vars for IPv4 addresses
+	IPV4_SRC = "${OTG_FLOW_SRC_IPV4}"
+	IPV4_DST = "${OTG_FLOW_DST_IPV4}"
+	// Default IPv4s are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
+	IPV4_DEFAULT_SRC = "192.0.2.1" // .1 == port  1
+	IPV4_DEFAULT_DST = "192.0.2.2" // .2 == port  2
+	// Env vars for IPv6 addresses
+	IPV6_SRC = "${OTG_FLOW_SRC_IPV6}"
+	IPV6_DST = "${OTG_FLOW_DST_IPV6}"
+	// Default IPv6s are link-local addresses based on default MAC addresses
+	IPV6_DEFAULT_SRC = "fe80::000:00ff:fe00:01aa"
+	IPV6_DEFAULT_DST = "fe80::000:00ff:fe00:02aa"
+	// Default device gateway and mask
+	IPV4_DEFAULT_GW     = "192.0.2.2"
+	IPV4_DEFAULT_PREFIX = 24
 )
 
 // createCmd represents the create command

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -80,3 +80,14 @@ func otgConfigHasPort(config gosnappi.Config, name string) bool {
 	}
 	return false
 }
+
+func otgGetOrCreatePort(config gosnappi.Config, name string, location string) gosnappi.Port {
+	for _, p := range config.Ports().Items() {
+		if p.Name() == name {
+			return p
+		}
+	}
+	p := config.Ports().Add().SetName(name)
+	p.SetLocation(envSubstOrDefault(location, location))
+	return p
+}

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -29,8 +29,7 @@ import (
 )
 
 var deviceName string    // Device name
-var deviceTxPort string  // Test port name for Tx
-var deviceRxPort string  // Test port name for Rx
+var devicePort string    // Test port name
 var deviceMac string     // Device ethernet MAC
 var deviceIPv4 string    // Device IPv4 address
 var deviceGWv4 string    // Device IPv4 default gateway
@@ -54,7 +53,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// set default MACs depending on Tx test port
-		switch deviceTxPort {
+		switch devicePort {
 		case PORT_NAME_P1:
 			if deviceMac == "" {
 				deviceMac = envSubstOrDefault(MAC_SRC_P1, MAC_DEFAULT_SRC)
@@ -64,7 +63,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 				deviceMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
 			}
 		default:
-			log.Fatalf("Unsupported test port name: %s", deviceTxPort)
+			log.Fatalf("Unsupported test port name: %s", devicePort)
 		}
 
 		return nil
@@ -86,11 +85,10 @@ func init() {
 
 	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "otg1", "Device name") // TODO when creating multiple devices, iterrate for the next available device index
 
-	deviceCmd.Flags().StringVarP(&deviceTxPort, "tx", "", PORT_NAME_P1, "Test port name for Tx")
-	deviceCmd.Flags().StringVarP(&deviceRxPort, "rx", "", PORT_NAME_P2, "Test port name for Rx")
+	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_P1, "Test port name")
 
 	deviceCmd.Flags().StringVarP(&deviceMac, "mac", "M", "", fmt.Sprintf("Device MAC address (default \"%s\")", MAC_DEFAULT_SRC))
-	deviceCmd.Flags().StringVarP(&deviceIPv4, "ip", "I", IPV4_DEFAULT_SRC, "Device IP address") // TODO consider IP/prefix format
+	deviceCmd.Flags().StringVarP(&deviceIPv4, "ip", "I", IPV4_DEFAULT_SRC, "Device IP address") // TODO consider IP/prefix format: split(a, "/")
 	deviceCmd.Flags().StringVarP(&deviceGWv4, "gw", "G", IPV4_DEFAULT_GW, "Device default gateway")
 	deviceCmd.Flags().Int32VarP(&devicePrefixv4, "prefix", "P", IPV4_DEFAULT_PREFIX, "Device network prefix")
 
@@ -131,8 +129,9 @@ func newDevice(config gosnappi.Config) {
 		SetName(deviceName + ".eth[0]").
 		SetMac(deviceMac)
 
-	deviceEth.Connection().
-		SetPortName(deviceTxPort)
+	// Connection is not yes available, tested with Ixia-c 0.0.1-3383
+	//deviceEth.Connection().SetPortName(devicePort)
+	deviceEth.SetPortName(devicePort)
 
 	deviceEth.Ipv4Addresses().Add().
 		SetName(deviceEth.Name() + ".ipv4[0]").

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2022 Open Traffic Generator
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/spf13/cobra"
+)
+
+// deviceCmd represents the device command
+var deviceCmd = &cobra.Command{
+	Use:   "device",
+	Short: "New OTG device configuration",
+	Long: `
+New OTG device configuration.
+
+For more information, go to https://github.com/open-traffic-generator/otgen
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if cmd.Parent().Use == createCmd.Use {
+			createDevice()
+		} else {
+			addDevice()
+		}
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(deviceCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deviceCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deviceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	var deviceCmdCreateCopy = *deviceCmd
+	var deviceCmdAddCopy = *deviceCmd
+
+	createCmd.AddCommand(&deviceCmdCreateCopy)
+	addCmd.AddCommand(&deviceCmdAddCopy)
+
+}
+
+func createDevice() {
+	// Create a new API handle
+	api := gosnappi.NewApi()
+
+	// Create a flow
+	newDevice(api.NewConfig())
+}
+
+func addDevice() {
+	// Create a new API handle
+	api := gosnappi.NewApi()
+
+	// Read pre-existing traffic configuration from STDIN and then create a flow
+	newDevice(readOtgStdin(api))
+}
+
+func newDevice(config gosnappi.Config) {
+	// Print traffic configuration constructed
+	otgYaml, err := config.ToYaml()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(otgYaml)
+}

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -58,11 +58,11 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		switch devicePort {
 		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly
 			if deviceMac == "" {
-				deviceMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
+				deviceMac = envSubstOrDefault(MAC_SRC_RX, MAC_DEFAULT_DST)
 			}
-		default: // assume p1
+		default: // PORT_NAME_TX
 			if deviceMac == "" {
-				deviceMac = envSubstOrDefault(MAC_SRC_P1, MAC_DEFAULT_SRC)
+				deviceMac = envSubstOrDefault(MAC_SRC_TX, MAC_DEFAULT_SRC)
 			}
 		}
 

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -105,13 +105,8 @@ func addDevice() {
 
 func newDevice(config gosnappi.Config) {
 	// Add port locations to the configuration
-	if !otgConfigHasPort(config, PORT_NAME_P1) {
-		config.Ports().Add().SetName(PORT_NAME_P1).SetLocation(envSubstOrDefault(PORT_LOCATION_P1, PORT_LOCATION_P1))
-	}
-
-	if !otgConfigHasPort(config, PORT_NAME_P2) {
-		config.Ports().Add().SetName(PORT_NAME_P2).SetLocation(envSubstOrDefault(PORT_LOCATION_P2, PORT_LOCATION_P2))
-	}
+	otgGetOrCreatePort(config, PORT_NAME_P1, PORT_LOCATION_P1)
+	otgGetOrCreatePort(config, PORT_NAME_P2, PORT_LOCATION_P2)
 
 	config.Devices().Add().SetName(deviceName)
 

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
@@ -54,16 +55,14 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// set default MACs depending on Tx test port
 		switch devicePort {
-		case PORT_NAME_P1:
-			if deviceMac == "" {
-				deviceMac = envSubstOrDefault(MAC_SRC_P1, MAC_DEFAULT_SRC)
-			}
 		case PORT_NAME_P2: // swap default SRC and DST MACs
 			if deviceMac == "" {
 				deviceMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
 			}
-		default:
-			log.Fatalf("Unsupported test port name: %s", devicePort)
+		default: // assume p1
+			if deviceMac == "" {
+				deviceMac = envSubstOrDefault(MAC_SRC_P1, MAC_DEFAULT_SRC)
+			}
 		}
 
 		return nil
@@ -118,8 +117,7 @@ func addDevice() {
 
 func newDevice(config gosnappi.Config) {
 	// Add port locations to the configuration
-	otgGetOrCreatePort(config, PORT_NAME_P1, PORT_LOCATION_P1)
-	otgGetOrCreatePort(config, PORT_NAME_P2, PORT_LOCATION_P2)
+	otgGetOrCreatePort(config, devicePort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)))
 
 	// Device name
 	device := config.Devices().Add().SetName(deviceName)

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -29,12 +29,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deviceName string    // Device name
-var devicePort string    // Test port name
-var deviceMac string     // Device ethernet MAC
-var deviceIPv4 string    // Device IPv4 address
-var deviceGWv4 string    // Device IPv4 default gateway
-var devicePrefixv4 int32 // Device IPv4 network prefix
+var deviceName string         // Device name
+var devicePort string         // Test port name
+var devicePortLocation string // Test port location string
+var deviceMac string          // Device ethernet MAC
+var deviceIPv4 string         // Device IPv4 address
+var deviceGWv4 string         // Device IPv4 default gateway
+var devicePrefixv4 int32      // Device IPv4 network prefix
 
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
@@ -65,6 +66,10 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 			}
 		}
 
+		if devicePortLocation == "" {
+			devicePortLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)), PORT_LOCATION_TX)
+		}
+
 		return nil
 	},
 }
@@ -85,6 +90,7 @@ func init() {
 	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", DEVICE_NAME_1, "Device name") // TODO when creating multiple devices, iterrate for the next available device index
 
 	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_P1, "Test port name")
+	deviceCmd.Flags().StringVarP(&devicePortLocation, "location", "l", "", fmt.Sprintf("Test port location string (default \"%s\")", PORT_LOCATION_TX))
 
 	deviceCmd.Flags().StringVarP(&deviceMac, "mac", "M", "", fmt.Sprintf("Device MAC address (default \"%s\")", MAC_DEFAULT_SRC))
 	deviceCmd.Flags().StringVarP(&deviceIPv4, "ip", "I", IPV4_DEFAULT_SRC, "Device IP address") // TODO consider IP/prefix format: split(a, "/")
@@ -117,7 +123,7 @@ func addDevice() {
 
 func newDevice(config gosnappi.Config) {
 	// Add port locations to the configuration
-	otgGetOrCreatePort(config, devicePort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)))
+	otgGetOrCreatePort(config, devicePort, devicePortLocation)
 
 	// Device name
 	device := config.Devices().Add().SetName(deviceName)

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -83,7 +83,7 @@ func init() {
 	// is called directly, e.g.:
 	// deviceCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", "otg1", "Device name") // TODO when creating multiple devices, iterrate for the next available device index
+	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", DEVICE_NAME_1, "Device name") // TODO when creating multiple devices, iterrate for the next available device index
 
 	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_P1, "Test port name")
 

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -56,7 +56,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// set default MACs depending on Tx test port
 		switch devicePort {
-		case PORT_NAME_P2: // swap default SRC and DST MACs
+		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly
 			if deviceMac == "" {
 				deviceMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
 			}
@@ -89,7 +89,7 @@ func init() {
 
 	deviceCmd.Flags().StringVarP(&deviceName, "name", "n", DEVICE_NAME_1, "Device name") // TODO when creating multiple devices, iterrate for the next available device index
 
-	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_P1, "Test port name")
+	deviceCmd.Flags().StringVarP(&devicePort, "port", "p", PORT_NAME_TX, "Test port name")
 	deviceCmd.Flags().StringVarP(&devicePortLocation, "location", "l", "", fmt.Sprintf("Test port location string (default \"%s\")", PORT_LOCATION_TX))
 
 	deviceCmd.Flags().StringVarP(&deviceMac, "mac", "M", "", fmt.Sprintf("Device MAC address (default \"%s\")", MAC_DEFAULT_SRC))

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -23,10 +23,7 @@ package cmd
 
 import (
 	"fmt"
-	"io"
-	"os"
 
-	"github.com/drone/envsubst"
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
 )
@@ -303,32 +300,4 @@ func newFlow(config gosnappi.Config) {
 		log.Fatal(err)
 	}
 	fmt.Print(otgYaml)
-}
-
-func readOtgStdin(api gosnappi.GosnappiApi) gosnappi.Config {
-	otgbytes, err := io.ReadAll(os.Stdin)
-	if err != nil {
-		log.Fatal(err)
-	}
-	otg := string(otgbytes)
-
-	config := api.NewConfig()
-	err = config.FromYaml(otg) // Thus YAML is assumed by default, and as a superset of JSON, it works for JSON format too
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	return config
-}
-
-// Substitute e with env variable of such name, if it is not empty, otherwise use default vaule d
-func envSubstOrDefault(e string, d string) string {
-	s, err := envsubst.EvalEnv(e)
-	if err != nil {
-		log.Fatal(err)
-	}
-	if s == "" {
-		s = d
-	}
-	return s
 }

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -218,13 +218,8 @@ func addFlow() {
 
 func newFlow(config gosnappi.Config) {
 	// Add port locations to the configuration
-	if !otgConfigHasPort(config, PORT_NAME_P1) {
-		config.Ports().Add().SetName(PORT_NAME_P1).SetLocation(envSubstOrDefault(PORT_LOCATION_P1, PORT_LOCATION_P1))
-	}
-
-	if !otgConfigHasPort(config, PORT_NAME_P2) {
-		config.Ports().Add().SetName(PORT_NAME_P2).SetLocation(envSubstOrDefault(PORT_LOCATION_P2, PORT_LOCATION_P2))
-	}
+	otgGetOrCreatePort(config, PORT_NAME_P1, PORT_LOCATION_P1)
+	otgGetOrCreatePort(config, PORT_NAME_P2, PORT_LOCATION_P2)
 
 	// Configure the flow and set the endpoints
 	flow := config.Flows().Add().SetName(flowName)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -23,6 +23,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
@@ -200,10 +201,6 @@ func addFlow() {
 }
 
 func newFlow(config gosnappi.Config) {
-	// Add port locations to the configuration
-	otgGetOrCreatePort(config, PORT_NAME_P1, PORT_LOCATION_P1)
-	otgGetOrCreatePort(config, PORT_NAME_P2, PORT_LOCATION_P2)
-
 	// Configure the flow name
 	flow := config.Flows().Add().SetName(flowName)
 
@@ -241,7 +238,7 @@ func newFlow(config gosnappi.Config) {
 		flow.TxRx().Device().SetTxNames([]string{deviceTx.Ethernets().Items()[0].Name()})
 		eth.Src().SetValue(deviceTx.Ethernets().Items()[0].Mac())
 	} else {
-		portTx := otgGetPort(config, flowTxPort)
+		portTx := otgGetOrCreatePort(config, flowTxPort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowTxPort)))
 		if portTx != nil {
 			flow.TxRx().Port().SetTxName(portTx.Name())
 			eth.Src().SetValue(flowSrcMac)
@@ -255,7 +252,7 @@ func newFlow(config gosnappi.Config) {
 		flow.TxRx().Device().SetRxNames([]string{deviceRx.Ethernets().Items()[0].Name()})
 		eth.Dst().SetValue(deviceRx.Ethernets().Items()[0].Mac()) // TODO this is a stub - use ARP instead
 	} else {
-		portRx := otgGetPort(config, flowRxPort)
+		portRx := otgGetOrCreatePort(config, flowRxPort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowRxPort)))
 		if portRx != nil {
 			flow.TxRx().Port().SetRxName(portRx.Name())
 			eth.Dst().SetValue(flowDstMac)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -43,6 +43,8 @@ const (
 var flowName string            // Flow name
 var flowTxPort string          // Test port name for Tx
 var flowRxPort string          // Test port name for Rx
+var flowTxLocation string      // Test port location string for Tx
+var flowRxLocation string      // Test port location srting for Rx
 var flowSrcMac string          // Source MAC address
 var flowDstMac string          // Destination MAC address
 var flowIPv4 bool              // IP version 4
@@ -93,6 +95,14 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 			if flowDstMac == "" {
 				flowDstMac = envSubstOrDefault(MAC_DST_P1, MAC_DEFAULT_DST)
 			}
+		}
+
+		if flowTxLocation == "" {
+			flowTxLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowTxPort)), PORT_LOCATION_TX)
+		}
+
+		if flowRxLocation == "" {
+			flowRxLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowRxPort)), PORT_LOCATION_RX)
 		}
 
 		if flowIPv6 {
@@ -146,6 +156,8 @@ func init() {
 
 	flowCmd.Flags().StringVarP(&flowTxPort, "tx", "", PORT_NAME_P1, "Test port name for Tx")
 	flowCmd.Flags().StringVarP(&flowRxPort, "rx", "", PORT_NAME_P2, "Test port name for Rx")
+	flowCmd.Flags().StringVarP(&flowTxLocation, "txl", "", "", fmt.Sprintf("Test port location string for Tx (default \"%s\")", PORT_LOCATION_TX))
+	flowCmd.Flags().StringVarP(&flowRxLocation, "rxl", "", "", fmt.Sprintf("Test port location string for Rx (default \"%s\")", PORT_LOCATION_RX))
 
 	flowCmd.Flags().StringVarP(&flowSrcMac, "smac", "S", "", fmt.Sprintf("Source MAC address (default \"%s\")", MAC_DEFAULT_SRC))
 	flowCmd.Flags().StringVarP(&flowDstMac, "dmac", "D", "", fmt.Sprintf("Destination MAC address (default \"%s\")", MAC_DEFAULT_DST))
@@ -238,7 +250,7 @@ func newFlow(config gosnappi.Config) {
 		flow.TxRx().Device().SetTxNames([]string{deviceTx.Ethernets().Items()[0].Name()})
 		eth.Src().SetValue(deviceTx.Ethernets().Items()[0].Mac())
 	} else {
-		portTx := otgGetOrCreatePort(config, flowTxPort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowTxPort)))
+		portTx := otgGetOrCreatePort(config, flowTxPort, flowTxLocation)
 		if portTx != nil {
 			flow.TxRx().Port().SetTxName(portTx.Name())
 			eth.Src().SetValue(flowSrcMac)
@@ -252,7 +264,7 @@ func newFlow(config gosnappi.Config) {
 		flow.TxRx().Device().SetRxNames([]string{deviceRx.Ethernets().Items()[0].Name()})
 		eth.Dst().SetValue(deviceRx.Ethernets().Items()[0].Mac()) // TODO this is a stub - use ARP instead
 	} else {
-		portRx := otgGetOrCreatePort(config, flowRxPort, stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(flowRxPort)))
+		portRx := otgGetOrCreatePort(config, flowRxPort, flowRxLocation)
 		if portRx != nil {
 			flow.TxRx().Port().SetRxName(portRx.Name())
 			eth.Dst().SetValue(flowDstMac)

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -81,7 +81,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		// set default MACs depending on Tx test port
 		switch flowTxPort {
-		case PORT_NAME_P2: // swap default SRC and DST MACs
+		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly
 			if flowSrcMac == "" {
 				flowSrcMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
 			}
@@ -154,8 +154,8 @@ func init() {
 
 	flowCmd.Flags().StringVarP(&flowName, "name", "n", "f1", "Flow name") // TODO when creating multiple flows, iterrate for the next available flow index
 
-	flowCmd.Flags().StringVarP(&flowTxPort, "tx", "", PORT_NAME_P1, "Test port name for Tx")
-	flowCmd.Flags().StringVarP(&flowRxPort, "rx", "", PORT_NAME_P2, "Test port name for Rx")
+	flowCmd.Flags().StringVarP(&flowTxPort, "tx", "", PORT_NAME_TX, "Test port name for Tx")
+	flowCmd.Flags().StringVarP(&flowRxPort, "rx", "", PORT_NAME_RX, "Test port name for Rx")
 	flowCmd.Flags().StringVarP(&flowTxLocation, "txl", "", "", fmt.Sprintf("Test port location string for Tx (default \"%s\")", PORT_LOCATION_TX))
 	flowCmd.Flags().StringVarP(&flowRxLocation, "rxl", "", "", fmt.Sprintf("Test port location string for Rx (default \"%s\")", PORT_LOCATION_RX))
 

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -32,20 +32,6 @@ import (
 )
 
 const (
-	// Env vars for port locations
-	PORT_LOCATION_P1 = "${OTG_LOCATION_P1}"
-	PORT_LOCATION_P2 = "${OTG_LOCATION_P2}"
-	// Test port names
-	PORT_NAME_P1 = "p1"
-	PORT_NAME_P2 = "p2"
-	// Env vars for MAC addresses
-	MAC_SRC_P1 = "${OTG_FLOW_SMAC_P1}"
-	MAC_DST_P1 = "${OTG_FLOW_DMAC_P1}"
-	MAC_SRC_P2 = "${OTG_FLOW_SMAC_P2}"
-	MAC_DST_P2 = "${OTG_FLOW_DMAC_P2}"
-	// Default MACs start with "02" to signify locally administered addresses (https://www.rfc-editor.org/rfc/rfc5342#section-2.1)
-	MAC_DEFAULT_SRC = "02:00:00:00:01:aa" // 01 == port 1, aa == otg side (bb == dut side)
-	MAC_DEFAULT_DST = "02:00:00:00:02:aa" // 02 == port 2, aa == otg side (bb == dut side)
 	// Env vars for IPv4 addresses
 	IPV4_SRC = "${OTG_FLOW_SRC_IPV4}"
 	IPV4_DST = "${OTG_FLOW_DST_IPV4}"
@@ -350,13 +336,4 @@ func envSubstOrDefault(e string, d string) string {
 		s = d
 	}
 	return s
-}
-
-func otgConfigHasPort(config gosnappi.Config, name string) bool {
-	for _, p := range config.Ports().Items() {
-		if p.Name() == name {
-			return true
-		}
-	}
-	return false
 }

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -92,6 +92,20 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 			if flowDstMac == "" {
 				flowDstMac = envSubstOrDefault(MAC_DST_P2, MAC_DEFAULT_SRC)
 			}
+		case DEVICE_NAME_1: // currently only a single-ethernet devices are supported
+			if flowSrcMac == "" {
+				flowSrcMac = envSubstOrDefault(MAC_SRC_P1, MAC_DEFAULT_SRC)
+			}
+			if flowDstMac == "" {
+				flowDstMac = envSubstOrDefault(MAC_DST_P1, MAC_DEFAULT_DST)
+			}
+		case DEVICE_NAME_2: // currently only a single-ethernet devices are supported
+			if flowSrcMac == "" {
+				flowSrcMac = envSubstOrDefault(MAC_SRC_P2, MAC_DEFAULT_DST)
+			}
+			if flowDstMac == "" {
+				flowDstMac = envSubstOrDefault(MAC_DST_P2, MAC_DEFAULT_SRC)
+			}
 		default:
 			log.Fatalf("Unsupported test port name: %s", flowTxPort)
 		}
@@ -208,8 +222,18 @@ func newFlow(config gosnappi.Config) {
 
 	// Configure the flow and set the endpoints
 	flow := config.Flows().Add().SetName(flowName)
-	flow.TxRx().Port().SetTxName(flowTxPort)
-	flow.TxRx().Port().SetRxName(flowRxPort)
+	switch flowTxPort {
+	case DEVICE_NAME_1:
+		flow.TxRx().Device().SetTxNames([]string{DEVICE_NAME_1 + ".eth[0]"})
+	default:
+		flow.TxRx().Port().SetTxName(flowTxPort)
+	}
+	switch flowRxPort {
+	case DEVICE_NAME_2:
+		flow.TxRx().Device().SetRxNames([]string{DEVICE_NAME_2 + ".eth[0]"})
+	default:
+		flow.TxRx().Port().SetRxName(flowRxPort)
+	}
 
 	// Configure the size of a packet and the number of packets to transmit
 	if flowFixedSize > 0 {

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -29,18 +29,6 @@ import (
 )
 
 const (
-	// Env vars for IPv4 addresses
-	IPV4_SRC = "${OTG_FLOW_SRC_IPV4}"
-	IPV4_DST = "${OTG_FLOW_DST_IPV4}"
-	// Default IPv4s are from IP ranges reserved for documentation (https://datatracker.ietf.org/doc/html/rfc5737#section-3)
-	IPV4_DEFAULT_SRC = "192.0.2.1" // .1 == port  1
-	IPV4_DEFAULT_DST = "192.0.2.2" // .2 == port  2
-	// Env vars for IPv6 addresses
-	IPV6_SRC = "${OTG_FLOW_SRC_IPV6}"
-	IPV6_DST = "${OTG_FLOW_DST_IPV6}"
-	// Default IPv6s are link-local addresses based on default MAC addresses
-	IPV6_DEFAULT_SRC = "fe80::000:00ff:fe00:01aa"
-	IPV6_DEFAULT_DST = "fe80::000:00ff:fe00:02aa"
 	// Transport protocols
 	PROTO_ICMP = "icmp"
 	PROTO_TCP  = "tcp"


### PR DESCRIPTION
```
otgen create device                   # Create OTG device configuration
  [--name string]                     # Device name (default otg1)
  [--port string]                     # Test port name (default p1)
  [--location string]                 # Test port location string (default localhost:5555)
  [--mac xx.xx.xx.xx.xx.xx]           # Device MAC address
  [--ip x.x.x.x]                      # Device IP address
  [--gw x.x.x.x]                      # Device default gateway
  [--prefix nn]                       # Device network prefix
```

Includes ability for flows to reference devices by name via `--tx/--rx`.
Includes `--txl/--rxl` parameters for flows to specify port locations.
Includes `--swap` capability for flows to reverse default values for tx/rx, MACs, IPs and TCP/UDP ports.