### PR TITLE
Improvements for `run` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ otgen create device                   # Create OTG device configuration
 
 ### `run`
 
-Request an OTG API endpoint to run OTG configuration.
+Requests OTG API endpoint to apply OTG configuration and run Traffic Flows.
 
 ```Shell
 otgen run 
-  [--api https://otg-api-endpoint]    # OTG server API endpoint (default is https://localhost)
+  [--api https://otg-api-endpoint]    # URL of OTG API endpoint. Overrides ENV:OTG_API (default "https://localhost")
   [--insecure]                        # Ignore X.509 certificate validation
   [--file otg.yml | --file otg.json]  # OTG model file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ otgen display --mode table
 
 ## Command reference
 
+### Global options
+
+```Shell
+otgen 
+  [--log level]                       # Logging level: err | warn | info | debug (default "err")
+```
+
 ### `create` and `add`
 
 Create a new OTG configuration item that can be further passed to stdin of `otgen run` command.

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ For such parameters it may be more convinient to change default values used by `
 Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
 
 ```Shell
+OTG_API                               # URL of OTG API endpoint
+
 OTG_LOCATION_%PORT_NAME%              # location for test port with a name PORT_NAME, for example:
 OTG_LOCATION_P1                       # location for test port "p1"
 OTG_LOCATION_P2                       # location for test port "p2"
@@ -160,6 +162,7 @@ OTG_FLOW_DST_IPV6                     # Destination IPv6 address to use for flow
 These are the values `otgen` uses if no variables or arguments were provided.
 
 ```Shell
+export OTG_API="https://localhost"
 export OTG_LOCATION_P1="localhost:5555"     # ixia-c-traffic-engine for p1 (tx) listening on localhost:5555
 export OTG_LOCATION_P2="localhost:5556"     # ixia-c-traffic-engine for p2 (rx) listening on localhost:5556
 export OTG_FLOW_SMAC_P1="02:00:00:00:01:aa"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	LOG_DEFAULT_LEVEL = "err"
+)
+
+var logLevel string // Logging level: error | info | debug
+
 // Create a new instance of the logger
 var log = logrus.New()
 
@@ -60,6 +66,7 @@ func init() {
 	// will be global for your application.
 
 	// rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.otgen.yaml)")
+	rootCmd.PersistentFlags().StringVarP(&logLevel, "log", "", LOG_DEFAULT_LEVEL, "Logging level: err | warn | info | debug")
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -66,6 +67,21 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		}
 
 		runTraffic(initOTG())
+	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		switch logLevel {
+		case "err":
+			log.SetLevel(logrus.ErrorLevel)
+		case "warn":
+			log.SetLevel(logrus.WarnLevel)
+		case "info":
+			log.SetLevel(logrus.InfoLevel)
+		case "debug":
+			log.SetLevel(logrus.DebugLevel)
+		default:
+			log.Fatalf("Unsupported log level: %s", logLevel)
+		}
+		return nil
 	},
 }
 
@@ -281,7 +297,7 @@ func checkResponse(res interface{}, err error) {
 		printMetricsResponseRawJson(v)
 	case gosnappi.ResponseWarning:
 		for _, w := range v.Warnings() {
-			log.Info("WARNING:", w)
+			log.Warn("WARNING:", w)
 		}
 	default:
 		log.Fatal("Unknown response type:", v)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -33,6 +33,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	OTG_API         = "${OTG_API}"        // Env var for API endpoint
+	OTG_DEFAULT_API = "https://localhost" // Default API endpoint value
+)
+
 var otgURL string                 // URL of OTG server API endpoint
 var otgIgnoreX509 bool            // Ignore X.509 certificate validation of OTG API endpoint
 var otgYaml bool                  // Format of OTG input is YAML. Mutually exclusive with --json
@@ -46,9 +51,9 @@ var xeta = float32(0.0)           // How long to wait before forcing traffic to 
 // runCmd represents the run command
 var runCmd = &cobra.Command{
 	Use:   "run",
-	Short: "Request an OTG API endpoint to run OTG model",
+	Short: "Requests OTG API endpoint to apply OTG configuration and run Traffic Flows",
 	Long: `
-Request an OTG API endpoint to run OTG model.
+Requests OTG API endpoint to apply OTG configuration and run Traffic Flows.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,
@@ -97,7 +102,7 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// runCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-	runCmd.Flags().StringVarP(&otgURL, "api", "a", "https://localhost", "URL of OTG API endpoint. Example: https://otg-api-endpoint")
+	runCmd.Flags().StringVarP(&otgURL, "api", "a", envSubstOrDefault(OTG_API, OTG_DEFAULT_API), "URL of OTG API endpoint. Overrides ENV:OTG_API")
 	runCmd.Flags().BoolVarP(&otgIgnoreX509, "insecure", "k", false, "Ignore X.509 certificate validation of OTG API endpoint")
 	runCmd.Flags().BoolVarP(&otgYaml, "yaml", "y", false, "Format of OTG input is YAML. Mutually exclusive with --json. Assumed format by default")
 	runCmd.Flags().BoolVarP(&otgJson, "json", "j", false, "Format of OTG input is JSON. Mutually exclusive with --yaml")


### PR DESCRIPTION
Parameters:

```
--log string   Logging level: err | warn | info | debug (default "err")
```

ENV vars:

```
OTG_API                               # URL of OTG API endpoint
```