### PR TITLE
Automatically start protocols as part of `run` command

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,9 +21,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
+        timeout-minutes: 3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.29
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build otgen
         run: cd ../../../.. && go get && go mod tidy && go build && sudo mv otgen /usr/local/bin/otgen
       - name: Setup testbed
-        run:  make install deploy && sleep 5
+        run:  make install pull deploy && sleep 5
       - name: Test1 RUN --rxbgp 2x
         run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x
       - name: Test2 RUN --rxbgp 2x --metrics bgp4

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build otgen
         run: cd ../../../.. && go get && go mod tidy && go build && sudo mv otgen /usr/local/bin/otgen
       - name: Setup testbed
-        run:  make install pull deploy
+        run:  make install deploy && sleep 5
       - name: Test1 RUN --rxbgp 2x
         run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x
       - name: Test2 RUN --rxbgp 2x --metrics bgp4

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -52,3 +52,30 @@ jobs:
         run:  otgen --log debug run -k --file otg.yml --xeta 1.5
       - name: Cleanup
         run:  make clean
+  dut-arp-bgp-traffic:
+    name: DUT ARP BGP and traffic test
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./test/otg-examples/docker-compose/cpdp-frr
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.ENV_GITHUB_USER }}
+          password: ${{ secrets.ENV_GITHUB_PAT }}
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Build otgen
+        run: cd ../../../.. && go get && go mod tidy && go build && sudo mv otgen /usr/local/bin/otgen
+      - name: Setup testbed
+        run:  make install pull deploy
+      - name: Pre-test
+        run:  make run

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -77,5 +77,17 @@ jobs:
         run: cd ../../../.. && go get && go mod tidy && go build && sudo mv otgen /usr/local/bin/otgen
       - name: Setup testbed
         run:  make install pull deploy
-      - name: Pre-test
-        run:  make run
+      - name: Test1 RUN --rxbgp 2x
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x
+      - name: Test2 RUN --rxbgp 2x --metrics bgp4
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics bgp4
+      - name: Test3 RUN --rxbgp 2x --metrics bgp4,port
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics bgp4,port
+      - name: Test4 RUN --rxbgp 2x --metrics bgp4,flow
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics bgp4,flow
+      - name: Test5 RUN --rxbgp 2x --metrics bgp4,flow,port
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics bgp4,flow,port
+      - name: Test5 RUN --rxbgp 2x --metrics flow,port
+        run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics flow,port
+      - name: Cleanup
+        run:  make clean

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ otgen run
   [--insecure]                        # Ignore X.509 certificate validation
   [--file otg.yml | --file otg.json]  # OTG configuration file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input
+  [--rxbgp 10|2x]                     # How many BGP routes shall we receive to consider the protocol is up. In number routes or multiples of routes advertised (default 1x)
   [--metrics port|flow]               # Metrics type to report: "port" for PortMetrics, "flow" for FlowMetrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)
@@ -141,7 +142,7 @@ For example:
    * `location` string of the OTG `ports` section depends on traffic generator ports available for the test
    * MAC addresses for OTG `flows` change only after re-deployment of containerized traffic generator components, and don't change in hardware setups
 
-For such parameters it may be more convinient to change default values used by `otgen` instead of specifying them as command-line arguments.
+For such parameters it may be more convenient to change default values used by `otgen` instead of specifying them as command-line arguments.
 
 Environmental variables is one of the mechanisms used by `otgen` to control default values. See below the full list of the variables recognized by `otgen` to redefine default values.
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ otgen run
   [--metrics port,flow,bgp4]          # Metrics types to report as a comma-separated list: "port" for PortMetrics, "flow" for FlowMetrics, "bgp4" for Bgpv4Metrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)
+  [--timeout 120]                     # Maximum total run time, including protocols convergence and running traffic
 ````
 
 ### `transform`

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ otgen run
   [--file otg.yml | --file otg.json]  # OTG configuration file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input
   [--rxbgp 10|2x]                     # How many BGP routes shall we receive to consider the protocol is up. In number routes or multiples of routes advertised (default 1x)
-  [--metrics port|flow]               # Metrics type to report: "port" for PortMetrics, "flow" for FlowMetrics
+  [--metrics port,flow,bgp4]          # Metrics types to report as a comma-separated list: "port" for PortMetrics, "flow" for FlowMetrics, "bgp4" for Bgpv4Metrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)
 ````

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ otgen run
   [--insecure]                        # Ignore X.509 certificate validation
   [--file otg.yml | --file otg.json]  # OTG configuration file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input
-  [--wait bgp]                        # Protocol to wait for to come up: "bgp4"
   [--metrics port|flow]               # Metrics type to report: "port" for PortMetrics, "flow" for FlowMetrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)

--- a/README.md
+++ b/README.md
@@ -72,13 +72,17 @@ otgen create device                   # Create OTG device configuration
 
 ### `run`
 
-Requests OTG API endpoint to apply OTG configuration and run Traffic Flows.
+Requests OTG API endpoint to:
+
+  * apply OTG configuration
+  * start Protocols, if any Devices are defined in the configuration
+  * run Traffic Flows
 
 ```Shell
 otgen run 
   [--api https://otg-api-endpoint]    # URL of OTG API endpoint. Overrides ENV:OTG_API (default "https://localhost")
   [--insecure]                        # Ignore X.509 certificate validation
-  [--file otg.yml | --file otg.json]  # OTG model file. If not provided, will use stdin
+  [--file otg.yml | --file otg.json]  # OTG configuration file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input
   [--metrics port|flow]               # Metrics type to report: "port" for PortMetrics, "flow" for FlowMetrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ otgen run
   [--insecure]                        # Ignore X.509 certificate validation
   [--file otg.yml | --file otg.json]  # OTG configuration file. If not provided, will use stdin
   [--yaml | --json]                   # Format of OTG input
+  [--wait bgp]                        # Protocol to wait for to come up: "bgp4"
   [--metrics port|flow]               # Metrics type to report: "port" for PortMetrics, "flow" for FlowMetrics
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -176,11 +176,6 @@ func startProtocols(api gosnappi.GosnappiApi, config gosnappi.Config) (gosnappi.
 					log.Debugf("Configuration has %s protocol", strings.ToUpper(proto))
 					configuredProtocols[proto] = true
 				}
-				proto = "bgp6"
-				if !configuredProtocols[proto] && len(d.Bgp().Ipv6Interfaces().Items()) > 0 {
-					log.Debugf("Configuration has %s protocol", strings.ToUpper(proto))
-					configuredProtocols[proto] = true
-				}
 			}
 		}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -171,13 +171,15 @@ func startProtocols(api gosnappi.GosnappiApi, config gosnappi.Config) (gosnappi.
 		var configuredProtocols = make(map[string]bool)
 		for _, d := range config.Devices().Items() {
 			if d.Bgp().RouterId() != "" {
-				if !configuredProtocols["bgp4"] && len(d.Bgp().Ipv4Interfaces().Items()) > 0 {
-					log.Debug("Configuration has BGP4 protocol")
-					configuredProtocols["bgp4"] = true
+				proto := "bgp4"
+				if !configuredProtocols[proto] && len(d.Bgp().Ipv4Interfaces().Items()) > 0 {
+					log.Debugf("Configuration has %s protocol", strings.ToUpper(proto))
+					configuredProtocols[proto] = true
 				}
-				if !configuredProtocols["bgp6"] && len(d.Bgp().Ipv6Interfaces().Items()) > 0 {
-					log.Debug("Configuration has BGP6 protocol")
-					configuredProtocols["bgp6"] = true
+				proto = "bgp6"
+				if !configuredProtocols[proto] && len(d.Bgp().Ipv6Interfaces().Items()) > 0 {
+					log.Debugf("Configuration has %s protocol", strings.ToUpper(proto))
+					configuredProtocols[proto] = true
 				}
 			}
 		}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -167,10 +167,8 @@ func startProtocols(api gosnappi.GosnappiApi, config gosnappi.Config) (gosnappi.
 		checkResponse(res, err)
 		log.Info("started...")
 
-		// A map of supported protocols and if they are present in the configuration
-		configuredProtocols := map[string]bool{
-			"bgp4": false,
-		}
+		// Detect protocols present in the configuration
+		var configuredProtocols = make(map[string]bool)
 		for _, d := range config.Devices().Items() {
 			if d.Bgp().RouterId() != "" {
 				if !configuredProtocols["bgp4"] && len(d.Bgp().Ipv4Interfaces().Items()) > 0 {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -158,7 +158,6 @@ func runTraffic(api gosnappi.GosnappiApi, config gosnappi.Config) {
 	log.Info("ready.")
 
 	// start configured protocols
-	// TODO stop at the end, consider defer
 	if len(config.Devices().Items()) > 0 { // TODO also if LAGs are configured
 		log.Info("Starting protocols...")
 		ps := api.NewProtocolState().SetState(gosnappi.ProtocolStateState.START)
@@ -216,11 +215,22 @@ func runTraffic(api gosnappi.GosnappiApi, config gosnappi.Config) {
 	}
 
 	// stop transmitting traffic
+	// TODO consider defer
 	log.Info("Stopping traffic...")
 	ts = api.NewTransmitState().SetState(gosnappi.TransmitStateState.STOP)
 	res, err = api.SetTransmitState(ts)
 	checkResponse(res, err)
 	log.Info("stopped.")
+
+	// stop protocols
+	// TODO consider defer
+	if len(config.Devices().Items()) > 0 { // TODO also if LAGs are configured
+		log.Info("Stopping protocols...")
+		ps := api.NewProtocolState().SetState(gosnappi.ProtocolStateState.STOP)
+		res, err = api.SetProtocolState(ps)
+		checkResponse(res, err)
+		log.Info("stopped.")
+	}
 }
 
 func calculateTrafficTargets(config gosnappi.Config) (int64, time.Duration) {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -213,18 +213,20 @@ func startProtocols(api gosnappi.GosnappiApi, config gosnappi.Config) (gosnappi.
 				}
 				protocolState[proto] = true
 				advertisedRoutes := int64(0)
+				receivedRoutes := int64(0)
 				for _, m := range res.Bgpv4Metrics().Items() {
 					// Check if protocol came up
 					if m.SessionState() != gosnappi.Bgpv4MetricSessionState.UP {
 						protocolState[proto] = false
 					} else {
 						advertisedRoutes += int64(m.RoutesAdvertised())
+						receivedRoutes += int64(m.RoutesReceived())
 					}
 				}
 				if protocolState[proto] {
-					if advertisedRoutes < routesPerProtocol[proto] {
+					log.Debugf("%s has advertised %d routes of total %d configured, and received %d routes...", strings.ToUpper(proto), advertisedRoutes, routesPerProtocol[proto], receivedRoutes)
+					if advertisedRoutes < routesPerProtocol[proto] || receivedRoutes < 2*advertisedRoutes {
 						// Not all configured routes we advertised yet
-						log.Debugf("%s has %d routes advertised of %d configured...", strings.ToUpper(proto), advertisedRoutes, routesPerProtocol[proto])
 						protocolState[proto] = false
 					}
 				} else {


### PR DESCRIPTION
* Start protocols if devices are present in the OTG configuration
* Wait for BGP protocol to come up, advertise all configured routes and receive an expected number of routes