### PR TITLE
`add bgp` capability

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -94,5 +94,7 @@ jobs:
         run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics bgp4,flow,port
       - name: Test7 RUN --rxbgp 2x --metrics flow,port
         run:  otgen --log debug run -k --file otg.json --json --rxbgp 2x --metrics flow,port
+      - name: Test8 CREATE --dmac auto | ADD BGP | RUN --rxbgp 2x --metrics bgp4,flow
+        run:  otgen create device -n otg1 -p p1 --ip 192.0.2.1 --gw 192.0.2.2 --prefix 30 | otgen add bgp -d otg1 --id 1.1.1.1 --asn 1111 --peer 192.0.2.2 --route 198.51.100.0/24 | otgen add device -n otg2 -p p2 --ip 192.0.2.5 --gw 192.0.2.6 --prefix 30 | otgen add bgp -d otg2 --id 2.2.2.2 --asn 2222 --peer 192.0.2.6 --route 203.0.113.0/24 | otgen add flow --tx otg1 --rx otg2 --dmac auto --src 198.51.100.1 --dst 203.0.113.1 | otgen --log debug run -k --rxbgp 2x --metrics bgp4,flow
       - name: Cleanup
         run:  make clean

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -1,0 +1,40 @@
+name: Unit Tests
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**.png'
+  push:
+    branches: [ "main" ]
+    paths:
+      - '**'
+      - '!**.md'
+      - '!**.png'
+  workflow_dispatch:
+
+env:
+  GOVER: 1.17.2
+
+jobs:
+  make-tests:
+    name: Make tests
+    runs-on: ubuntu-20.04
+    env:
+      OTG_LOCATION_P1: "localhost:5555+localhost:50071"
+      OTG_LOCATION_P2: "localhost:5556+localhost:50072"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: 'true'
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GOVER }}
+      - name: Build
+        run: make get build
+      - name: Tests
+        run:  make tests

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,9 +22,6 @@ jobs:
   make-tests:
     name: Make tests
     runs-on: ubuntu-20.04
-    env:
-      OTG_LOCATION_P1: "localhost:5555+localhost:50071"
-      OTG_LOCATION_P2: "localhost:5556+localhost:50072"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/BUILD.md
+++ b/BUILD.md
@@ -21,6 +21,7 @@ cobra-cli add create --license mit --author "Open Traffic Generator"
 cobra-cli add add --license mit --author "Open Traffic Generator"
 cobra-cli add flow --license mit --author "Open Traffic Generator" # subcommand for create and add
 cobra-cli add device --license mit --author "Open Traffic Generator" # subcommand for create and add
+cobra-cli add bgp --license mit --author "Open Traffic Generator" # subcommand for add
 ```
 
 ### GoReleaser

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ tests-add-bgp:
 	@echo
 	@echo "# Incorrect ASN parameter"
 	./otgen create device | \
-	./otgen --log debug add bgp --asn 11111111 && echo "Expected to fail" && exit 1 || echo Passed
+	./otgen --log debug add bgp --asn 4294967296 && echo "Expected to fail" && exit 1 || echo Passed
 
 	@echo
 	@echo "# Updating ASN"

--- a/Makefile
+++ b/Makefile
@@ -79,4 +79,12 @@ tests-add-bgp:
 	./otgen --log debug add bgp --device r1 | \
 	diff test/add/bgp-device.name.yml -
 
+	./otgen create device | \
+	./otgen --log debug add bgp --asn 1111 | \
+	diff test/add/bgp-device.asn.yml -
+
+	./otgen create device | \
+	./otgen --log debug add bgp --peer 192.0.2.200 | \
+	diff test/add/bgp-device.peer.yml -
+
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -67,94 +67,116 @@ tests-add-bgp:
 	@echo "#################################################################"
 	@echo "# Add BGP configuration to a device"
 	@echo "#################################################################"
-	./otgen create device --name r1 | \
-	./otgen --log debug add bgp || \
-	echo "Passed"
 
+	@echo
+	@echo "# Add bgp defaults"
 	./otgen create device | \
 	./otgen --log debug add bgp | \
 	diff test/add/bgp-device.defaults.yml -
 
+	@echo
+	@echo "# Add bgp with --device"
 	./otgen create device --name r1 | \
 	./otgen --log debug add bgp --device r1 | \
 	diff test/add/bgp-device.name.yml -
 
 	@echo
-	@echo "# Adding the same BGP twice"
+	@echo "# Add BGP to a non-existent device"
+	./otgen create device --name r1 | \
+	./otgen --log debug add bgp && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Adding the same BGP configuration twice"
 	./otgen create device | \
 	./otgen add bgp | \
 	./otgen --log debug add bgp | \
 	diff test/add/bgp-device.defaults.yml -
 
-	./otgen create device | \
-	./otgen --log debug add bgp --id 1111 && echo "Expected to fail" && exit 1 || echo Passed
-
+	@echo
+	@echo "# Add BGP with router --id"
 	./otgen create device | \
 	./otgen --log debug add bgp --id 1.1.1.1 | \
 	diff test/add/bgp-device.id.yml -
 
 	@echo
-	@echo "# Updating BGP router id"
+	@echo "# Add BGP with non-IPv4 router --id"
+	./otgen create device | \
+	./otgen --log debug add bgp --id 1111 && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Updating BGP router --id"
 	./otgen create device | \
 	./otgen add bgp | \
 	./otgen --log debug add bgp --id 1.1.1.1 | \
 	diff test/add/bgp-device.id.yml -
 
 	@echo
-	@echo "# ASN parameter"
+	@echo "# Add BGP with --asn"
 	./otgen create device | \
 	./otgen --log debug add bgp --asn 1111 | \
 	diff test/add/bgp-device.asn.yml -
 
 	@echo
-	@echo "# Incorrect ASN parameter"
+	@echo "# Add BGP with incorrect --asn ASN"
 	./otgen create device | \
 	./otgen --log debug add bgp --asn 4294967296 && echo "Expected to fail" && exit 1 || echo Passed
 
 	@echo
-	@echo "# Updating ASN"
+	@echo "# Updating BGP --asn"
 	./otgen create device | \
 	./otgen add bgp | \
 	./otgen --log debug add bgp --asn 1111 | \
 	diff test/add/bgp-device.asn.yml -
 
+	@echo
+	@echo "# Add BGP with --peer"
 	./otgen create device | \
 	./otgen --log debug add bgp --peer 192.0.2.200 | \
 	diff test/add/bgp-device.peer.yml -
 
-	./otgen create device | \
-	./otgen --log debug add bgp --peer 192.0.2.200 --type wrong && echo "Expected to fail" && exit 1 || echo Passed
-
+	@echo
+	@echo "# Add BGP with peering --type"
 	./otgen create device | \
 	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \
 	diff test/add/bgp-device.type.yml -
 
 	@echo
-	@echo "# Updating BGP peering type"
+	@echo "# Add BGP with wrong peering --type"
+	./otgen create device | \
+	./otgen --log debug add bgp --peer 192.0.2.200 --type wrong && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Updating BGP peering --type"
 	./otgen create device | \
 	./otgen add bgp --peer 192.0.2.200 | \
 	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \
 	diff test/add/bgp-device.type.yml -
 
-	./otgen create device | \
-	./otgen --log debug add bgp --route 198.51.100.0 || \
-	echo "Passed"
-
-	./otgen create device | \
-	./otgen --log debug add bgp --route /24 || \
-	echo "Passed"
-
-	./otgen create device | \
-	./otgen --log debug add bgp --route 198.51.100.0/33 || \
-	echo "Passed"
-
-	./otgen create device | \
-	./otgen --log debug add bgp --route 198.51.100.256/32 || \
-	echo "Passed"
-
+	@echo
+	@echo "# Add BGP with --route"
 	./otgen create device | \
 	./otgen --log debug add bgp --route 198.51.100.0/24 | \
 	diff test/add/bgp-device.route.yml -
+
+	@echo
+	@echo "# Add BGP with --route w/o netmask prefix"
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.0 && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Add BGP with --route w/o address part"
+	./otgen create device | \
+	./otgen --log debug add bgp --route /24 && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Add BGP with --route with wrong netmask prefix"
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.0/33 && echo "Expected to fail" && exit 1 || echo Passed
+
+	@echo
+	@echo "# Add BGP with --route with wrong address"
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.256/32 && echo "Expected to fail" && exit 1 || echo Passed
 
 	@echo
 	@echo "# Adding same route twice"

--- a/Makefile
+++ b/Makefile
@@ -88,6 +88,13 @@ tests-add-bgp:
 	diff test/add/bgp-device.peer.yml -
 
 	./otgen create device | \
+	./otgen --log debug add bgp --peer 192.0.2.200 --type wrong && echo "Expected to fail" && exit 1 || echo Passed
+
+	./otgen create device | \
+	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \
+	diff test/add/bgp-device.type.yml -
+
+	./otgen create device | \
 	./otgen --log debug add bgp --route 198.51.100.0 || \
 	echo "Passed"
 

--- a/Makefile
+++ b/Makefile
@@ -150,3 +150,17 @@ tests-add-bgp:
 	diff test/add/bgp-device.route.yml -
 
 	@echo
+	@echo "# Adding same route twice"
+	./otgen create device | \
+	./otgen add bgp --route 198.51.100.0/24 | \
+	./otgen --log debug add bgp --route 198.51.100.0/24 | \
+	diff test/add/bgp-device.route.yml -
+
+	@echo
+	@echo "# Adding second route"
+	./otgen create device | \
+	./otgen add bgp --route 198.51.100.0/24 | \
+	./otgen --log debug add bgp --route 198.51.101.0/24 | \
+	diff test/add/bgp-device.2route.yml -
+
+	@echo

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ tests-create-devices-flow:
 
 	@echo
 
+tests-add-bgp: export OTG_LOCATION_P1 = localhost:5555+localhost:50071
 tests-add-bgp:
 	@echo "#################################################################"
 	@echo "# Add BGP configuration to a device"

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ tests-add-bgp:
 	@echo "# Add BGP configuration to a device"
 	@echo "#################################################################"
 	./otgen create device  | \
-	./otgen add    bgp
+	./otgen add    bgp     | \
+	diff test/add/bgp-device.defaults.yml -
 
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -67,8 +67,16 @@ tests-add-bgp:
 	@echo "#################################################################"
 	@echo "# Add BGP configuration to a device"
 	@echo "#################################################################"
+	./otgen create device --name r1 | \
+	./otgen add    bgp || \
+	echo "Passed"
+
 	./otgen create device  | \
 	./otgen add    bgp     | \
 	diff test/add/bgp-device.defaults.yml -
+
+	./otgen create device --name r1 | \
+	./otgen add    bgp  --device r1    | \
+	diff test/add/bgp-device.name.yml -
 
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,13 @@ tests-add-bgp:
 	./otgen --log debug add bgp --device r1 | \
 	diff test/add/bgp-device.name.yml -
 
+	@echo
+	@echo "# Adding the same BGP twice"
+	./otgen create device | \
+	./otgen add bgp | \
+	./otgen --log debug add bgp | \
+	diff test/add/bgp-device.defaults.yml -
+
 	./otgen create device | \
 	./otgen --log debug add bgp --id 1111 && echo "Expected to fail" && exit 1 || echo Passed
 
@@ -86,7 +93,21 @@ tests-add-bgp:
 	./otgen --log debug add bgp --id 1.1.1.1 | \
 	diff test/add/bgp-device.id.yml -
 
+	@echo
+	@echo "# Updating BGP router id"
 	./otgen create device | \
+	./otgen add bgp | \
+	./otgen --log debug add bgp --id 1.1.1.1 | \
+	diff test/add/bgp-device.id.yml -
+
+	./otgen create device | \
+	./otgen --log debug add bgp --asn 1111 | \
+	diff test/add/bgp-device.asn.yml -
+
+	@echo
+	@echo "# Updating ASN"
+	./otgen create device | \
+	./otgen add bgp | \
 	./otgen --log debug add bgp --asn 1111 | \
 	diff test/add/bgp-device.asn.yml -
 
@@ -98,6 +119,13 @@ tests-add-bgp:
 	./otgen --log debug add bgp --peer 192.0.2.200 --type wrong && echo "Expected to fail" && exit 1 || echo Passed
 
 	./otgen create device | \
+	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \
+	diff test/add/bgp-device.type.yml -
+
+	@echo
+	@echo "# Updating BGP peering type"
+	./otgen create device | \
+	./otgen add bgp --peer 192.0.2.200 | \
 	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \
 	diff test/add/bgp-device.type.yml -
 

--- a/Makefile
+++ b/Makefile
@@ -136,6 +136,12 @@ tests-add-bgp:
 	diff test/add/bgp-device.peer.yml -
 
 	@echo
+	@echo "# Use default gw as a peer by default"
+	./otgen create device --gw 192.0.2.200 | \
+	./otgen --log debug add bgp | \
+	diff test/add/bgp-device.peer-default-gw.yml -
+
+	@echo
 	@echo "# Add BGP with peering --type"
 	./otgen create device | \
 	./otgen --log debug add bgp --peer 192.0.2.200 --type ibgp | \

--- a/Makefile
+++ b/Makefile
@@ -68,15 +68,15 @@ tests-add-bgp:
 	@echo "# Add BGP configuration to a device"
 	@echo "#################################################################"
 	./otgen create device --name r1 | \
-	./otgen add    bgp || \
+	./otgen --log debug add bgp || \
 	echo "Passed"
 
-	./otgen create device  | \
-	./otgen add    bgp     | \
+	./otgen create device | \
+	./otgen --log debug add bgp | \
 	diff test/add/bgp-device.defaults.yml -
 
 	./otgen create device --name r1 | \
-	./otgen add    bgp  --device r1    | \
+	./otgen --log debug add bgp --device r1 | \
 	diff test/add/bgp-device.name.yml -
 
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ tests-add-bgp:
 	diff test/add/bgp-device.name.yml -
 
 	./otgen create device | \
+	./otgen --log debug add bgp --id 1111 && echo "Expected to fail" && exit 1 || echo Passed
+
+	./otgen create device | \
+	./otgen --log debug add bgp --id 1.1.1.1 | \
+	diff test/add/bgp-device.id.yml -
+
+	./otgen create device | \
 	./otgen --log debug add bgp --asn 1111 | \
 	diff test/add/bgp-device.asn.yml -
 

--- a/Makefile
+++ b/Makefile
@@ -100,9 +100,16 @@ tests-add-bgp:
 	./otgen --log debug add bgp --id 1.1.1.1 | \
 	diff test/add/bgp-device.id.yml -
 
+	@echo
+	@echo "# ASN parameter"
 	./otgen create device | \
 	./otgen --log debug add bgp --asn 1111 | \
 	diff test/add/bgp-device.asn.yml -
+
+	@echo
+	@echo "# Incorrect ASN parameter"
+	./otgen create device | \
+	./otgen --log debug add bgp --asn 11111111 && echo "Expected to fail" && exit 1 || echo Passed
 
 	@echo
 	@echo "# Updating ASN"

--- a/Makefile
+++ b/Makefile
@@ -87,4 +87,24 @@ tests-add-bgp:
 	./otgen --log debug add bgp --peer 192.0.2.200 | \
 	diff test/add/bgp-device.peer.yml -
 
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.0 || \
+	echo "Passed"
+
+	./otgen create device | \
+	./otgen --log debug add bgp --route /24 || \
+	echo "Passed"
+
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.0/33 || \
+	echo "Passed"
+
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.256/32 || \
+	echo "Passed"
+
+	./otgen create device | \
+	./otgen --log debug add bgp --route 198.51.100.0/24 | \
+	diff test/add/bgp-device.route.yml -
+
 	@echo

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ get:
 build:
 	go build -ldflags="-X 'github.com/open-traffic-generator/otgen/cmd.version=v0.0.0-${USER}'"
 
-tests: tests-create tests-create-devices-flow
+tests: tests-create tests-create-devices-flow tests-add-bgp
 
 tests-create: tests-create-flow-raw
 
@@ -60,5 +60,14 @@ tests-create-devices-flow:
 	./otgen add    device -n otg2 -p p2 --ip 192.0.2.5 --gw 192.0.2.6 --prefix 30 --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg1 --rx otg2 --dmac auto --src 192.0.2.1 --dst 192.0.2.5 | \
 	diff test/create/flow-device.mac.auto.yml -
+
+	@echo
+
+tests-add-bgp:
+	@echo "#################################################################"
+	@echo "# Add BGP configuration to a device"
+	@echo "#################################################################"
+	./otgen create device  | \
+	./otgen add    bgp
 
 	@echo

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ otgen add bgp                         # Add a BGP configuration to an Emulated D
   [--device string]                   # Device name to add BGP configuration to (default "otg1")
   [--asn N]                           # Autonomous System Number (default 65535)
   [--peer x.x.x.x]                    # Peer IP address (default "192.0.2.2")
+  [--type ebgp|ibgp]                  # BGP peering type: ebgp | ibgp (default "ebgp")
   [--route x.x.x.x/nn]                # Route to advertise
 ```
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ otgen create device                   # Create a configuration for an Emulated D
 ```Shell
 otgen add bgp                         # Add a BGP configuration to an Emulated Device
   [--device string]                   # Device name to add BGP configuration to (default "otg1")
+  [--id]                              # Router ID (default is an IP address of the interface the BGP configuration is attached to)
   [--asn N]                           # Autonomous System Number (default 65535)
   [--peer x.x.x.x]                    # Peer IP address (default "192.0.2.2")
   [--type ebgp|ibgp]                  # BGP peering type: ebgp | ibgp (default "ebgp")

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ otgen add bgp                         # Add a BGP configuration to an Emulated D
   [--device string]                   # Device name to add BGP configuration to (default "otg1")
   [--id]                              # Router ID (default is an IP address of the interface the BGP configuration is attached to)
   [--asn N]                           # Autonomous System Number (default 65535)
-  [--peer x.x.x.x]                    # Peer IP address (default "192.0.2.2")
+  [--peer x.x.x.x]                    # Peer IP address (default is a GW address of the interface the BGP configuration is attached to)
   [--type ebgp|ibgp]                  # BGP peering type: ebgp | ibgp (default "ebgp")
   [--route x.x.x.x/nn]                # Route to advertise
 ```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ otgen create device                   # Create a configuration for an Emulated D
 otgen add bgp                         # Add a BGP configuration to an Emulated Device
   [--device string]                   # Device name to add BGP configuration to (default "otg1")
   [--id]                              # Router ID (default is an IP address of the interface the BGP configuration is attached to)
-  [--asn N]                           # Autonomous System Number (default 65535)
+  [--asn N]                           # Autonomous System Number (default 65534)
   [--peer x.x.x.x]                    # Peer IP address (default is a GW address of the interface the BGP configuration is attached to)
   [--type ebgp|ibgp]                  # BGP peering type: ebgp | ibgp (default "ebgp")
   [--route x.x.x.x/nn]                # Route to advertise

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Create a new OTG configuration item that can be further passed to stdin of `otge
 The `add` variant of the command first reads an OTG configuration from stdin.
 
 ```Shell
-otgen create flow                     # Create OTG flow configuration
+otgen create flow                     # Create a configuration for a Traffic Flow
   [--name string]                     # Flow name (default f1)
   [--tx string]                       # Test port name for TX (default p1) 
   [--rx string]                       # Test port name for RX (default p2) 
@@ -61,7 +61,7 @@ otgen create flow                     # Create OTG flow configuration
 ```
 
 ```Shell
-otgen create device                   # Create OTG device configuration
+otgen create device                   # Create a configuration for an Emulated Device
   [--name string]                     # Device name (default otg1)
   [--port string]                     # Test port name (default p1)
   [--location string]                 # Test port location string (default localhost:5555)
@@ -71,12 +71,22 @@ otgen create device                   # Create OTG device configuration
   [--prefix nn]                       # Device network prefix
 ```
 
+### `add bgp`
+
+```Shell
+otgen add bgp                         # Add a BGP configuration to an Emulated Device
+  [--device string]                   # Device name (default otg1)
+  [--asn N]                           # Autonomous System Number
+  [--peer x.x.x.x]                    # Peer IP address
+  [--route x.x.x.x/nn]                # Route to advertise
+```
+
 
 ### `run`
 
 Requests OTG API endpoint to:
 
-  * apply OTG configuration
+  * apply an OTG configuration
   * start Protocols, if any Devices are defined in the configuration
   * run Traffic Flows
 

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ otgen create device                   # Create a configuration for an Emulated D
 
 ```Shell
 otgen add bgp                         # Add a BGP configuration to an Emulated Device
-  [--device string]                   # Device name to add BGP configuration to (default otg1)
-  [--asn N]                           # Autonomous System Number
-  [--peer x.x.x.x]                    # Peer IP address
+  [--device string]                   # Device name to add BGP configuration to (default "otg1")
+  [--asn N]                           # Autonomous System Number (default 65535)
+  [--peer x.x.x.x]                    # Peer IP address (default "192.0.2.2")
   [--route x.x.x.x/nn]                # Route to advertise
 ```
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ otgen create device                   # Create a configuration for an Emulated D
 
 ```Shell
 otgen add bgp                         # Add a BGP configuration to an Emulated Device
-  [--device string]                   # Device name (default otg1)
+  [--device string]                   # Device name to add BGP configuration to (default otg1)
   [--asn N]                           # Autonomous System Number
   [--peer x.x.x.x]                    # Peer IP address
   [--route x.x.x.x/nn]                # Route to advertise

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -38,6 +38,10 @@ The output can be passed to stdin of "otgen run" or another "otgen add" command.
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Error("You must specify an OTG configuration object to add, one of the following: flow | device | bgp")
 	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -30,6 +30,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	BGP_ASN_MIN     = int32(1)     // Minimum value for ASN
+	BGP_ASN_MAX     = int32(65535) // Maximin value for ASN
+	BGP_ASN_DEFAULT = int32(65535) // Default ASN value
+)
+
 var bgpDeviceName string                     // Device name to add BGP configuration to
 var bgpRouterID string                       // Router ID
 var bgpASN int32                             // Autonomous System Number
@@ -54,6 +60,9 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		setLogLevel(cmd, logLevel)
+		if bgpASN < BGP_ASN_MIN || bgpASN > BGP_ASN_MAX {
+			log.Fatalf("ASN provided is out of range %d-%d: %d", BGP_ASN_MIN, BGP_ASN_MAX, bgpASN)
+		}
 		switch bgpType {
 		case "ebgp", "eBGP", "EBGP", "e":
 			bgpTypeEnum = gosnappi.BgpV4PeerAsType.EBGP
@@ -98,7 +107,7 @@ func init() {
 
 	bgpCmd.Flags().StringVarP(&bgpRouterID, "id", "", "", "Router ID (default is an IP address of the interface the BGP configuration is attached to)")
 	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to")
-	bgpCmd.Flags().Int32VarP(&bgpASN, "asn", "", 65535, "Autonomous System Number")
+	bgpCmd.Flags().Int32VarP(&bgpASN, "asn", "", BGP_ASN_DEFAULT, "Autonomous System Number")
 	bgpCmd.Flags().StringVarP(&bgpPeerIP, "peer", "p", IPV4_DEFAULT_GW, "Peer IP address")
 	bgpCmd.Flags().StringVarP(&bgpType, "type", "t", string(gosnappi.BgpV4PeerAsType.EBGP), "BGP peering type: ebgp | ibgp")
 	bgpCmd.Flags().StringVarP(&bgpRoute, "route", "r", "", "Route to advertise")
@@ -151,9 +160,9 @@ func newBgp(config gosnappi.Config) {
 			bgpIPv4Peer = bgpIPv4Interface.Peers().Add().SetName(bgpDeviceIPv4Interface.Name() + ".bgp.peer." + bgpPeerIP)
 		}
 
-		bgpIPv4Peer.SetAsNumber(bgpASN).SetAsType(bgpTypeEnum)
-		bgpIPv4Peer.SetPeerAddress(bgpPeerIP) // TODO check if it is IPv6
-		if bgpRoute != "" {                   // TODO IPv6
+		bgpIPv4Peer.SetAsNumber(bgpASN).SetAsType(bgpTypeEnum) // TODO update as_number_width for longer ASNs
+		bgpIPv4Peer.SetPeerAddress(bgpPeerIP)                  // TODO check if it is IPv6
+		if bgpRoute != "" {                                    // TODO IPv6
 			var bgpIPv4PeerRouteRange gosnappi.BgpV4RouteRange
 			for _, v := range bgpIPv4Peer.V4Routes().Items() {
 				if v.HasNextHopMode() && v.NextHopMode() == gosnappi.BgpV4RouteRangeNextHopMode.LOCAL_IP {

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -28,6 +28,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var bgpDeviceName string // Device name to add BGP configuration to
+
 // bgpCmd represents the bgp command
 var bgpCmd = &cobra.Command{
 	Use:   "bgp",
@@ -58,6 +60,8 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// bgpCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+
+	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to ")
 }
 
 func addBgp() {
@@ -69,6 +73,14 @@ func addBgp() {
 }
 
 func newBgp(config gosnappi.Config) {
+	// First, see if we have a device with the specified name
+	device := otgGetDevice(config, bgpDeviceName)
+	if device == nil {
+		log.Fatalf("No such device in the provided OTG configuration: %s", bgpDeviceName)
+	}
+	log.Debugf("Found matching device name: %s", bgpDeviceName)
+	device.Bgp().SetRouterId(device.Ethernets().Items()[0].Ipv4Addresses().Items()[0].Address())
+
 	// Print the OTG configuration constructed
 	otgYaml, err := config.ToYaml()
 	if err != nil {

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -39,6 +39,10 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("bgp called")
 	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -22,34 +22,35 @@ THE SOFTWARE.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
-// addCmd represents the add command
-var addCmd = &cobra.Command{
-	Use:   "add",
-	Short: "Read an OTG configuration from stdin and add the specified item",
+// bgpCmd represents the bgp command
+var bgpCmd = &cobra.Command{
+	Use:   "bgp",
+	Short: "Add a BGP configuration to an Emulated Device",
 	Long: `
-Read an OTG configuration from stdin and add the specified item. 
-The output can be passed to stdin of "otgen run" or another "otgen add" command.
+Add a BGP configuration to an Emulated Device
 
-  For more information, go to https://github.com/open-traffic-generator/otgen
+For more information, go to https://github.com/open-traffic-generator/otgen
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Error("You must specify an OTG configuration object to add, one of the following: flow | device | bgp")
+		fmt.Println("bgp called")
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(addCmd)
+	addCmd.AddCommand(bgpCmd)
 
 	// Here you will define your flags and configuration settings.
 
 	// Cobra supports Persistent Flags which will work for this command
 	// and all subcommands, e.g.:
-	// addCmd.PersistentFlags().String("foo", "", "A help for foo")
+	// bgpCmd.PersistentFlags().String("foo", "", "A help for foo")
 
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
-	// addCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	// bgpCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -79,7 +79,12 @@ func newBgp(config gosnappi.Config) {
 		log.Fatalf("No such device in the provided OTG configuration: %s", bgpDeviceName)
 	}
 	log.Debugf("Found matching device name: %s", bgpDeviceName)
-	device.Bgp().SetRouterId(device.Ethernets().Items()[0].Ipv4Addresses().Items()[0].Address())
+	bgpDeviceIPv4Interface := device.Ethernets().Items()[0].Ipv4Addresses().Items()[0]
+	if bgpDeviceIPv4Interface != nil { // TODO IPv6
+		log.Debugf("Adding BGP to the device's IPv4 interface: %s", bgpDeviceIPv4Interface.Address())
+		device.Bgp().SetRouterId(bgpDeviceIPv4Interface.Address()) // TODO parameterize router_id
+		device.Bgp().Ipv4Interfaces().Add().SetIpv4Name(bgpDeviceIPv4Interface.Name())
+	}
 
 	// Print the OTG configuration constructed
 	otgYaml, err := config.ToYaml()

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -24,6 +24,7 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/open-traffic-generator/snappi/gosnappi"
 	"github.com/spf13/cobra"
 )
 
@@ -37,7 +38,7 @@ Add a BGP configuration to an Emulated Device
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("bgp called")
+		addBgp()
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		setLogLevel(cmd, logLevel)
@@ -57,4 +58,21 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// bgpCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}
+
+func addBgp() {
+	// Create a new API handle
+	api := gosnappi.NewApi()
+
+	// Read pre-existing traffic configuration from STDIN and then add a BGP
+	newBgp(readOtgStdin(api))
+}
+
+func newBgp(config gosnappi.Config) {
+	// Print the OTG configuration constructed
+	otgYaml, err := config.ToYaml()
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Print(otgYaml)
 }

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -31,14 +31,14 @@ import (
 )
 
 const (
-	BGP_ASN_MIN     = int32(1)     // Minimum value for ASN
-	BGP_ASN_MAX     = int32(65535) // Maximin value for ASN
-	BGP_ASN_DEFAULT = int32(65535) // Default ASN value
+	BGP_ASN_MIN     = uint32(0)          // Minimum value for ASN
+	BGP_ASN_MAX     = uint32(2147483647) // Maximin value for ASN (4-byte), should be uint32(4294967294) but gosnappi uses signed int32 and that leads to negative values
+	BGP_ASN_DEFAULT = uint32(65534)      // Default ASN value
 )
 
 var bgpDeviceName string                     // Device name to add BGP configuration to
 var bgpRouterID string                       // Router ID
-var bgpASN int32                             // Autonomous System Number
+var bgpASN uint32                            // Autonomous System Number
 var bgpType string                           // BGP peering type: ebgp | ibgp
 var bgpTypeEnum gosnappi.BgpV4PeerAsTypeEnum // BGP peering type as gosnappi enum
 var bgpPeerIP string                         // Peer IP address
@@ -107,7 +107,7 @@ func init() {
 
 	bgpCmd.Flags().StringVarP(&bgpRouterID, "id", "", "", "Router ID (default is an IP address of the interface the BGP configuration is attached to)")
 	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to")
-	bgpCmd.Flags().Int32VarP(&bgpASN, "asn", "", BGP_ASN_DEFAULT, "Autonomous System Number")
+	bgpCmd.Flags().Uint32VarP(&bgpASN, "asn", "", BGP_ASN_DEFAULT, "Autonomous System Number")
 	bgpCmd.Flags().StringVarP(&bgpPeerIP, "peer", "p", IPV4_DEFAULT_GW, "Peer IP address")
 	bgpCmd.Flags().StringVarP(&bgpType, "type", "t", string(gosnappi.BgpV4PeerAsType.EBGP), "BGP peering type: ebgp | ibgp")
 	bgpCmd.Flags().StringVarP(&bgpRoute, "route", "r", "", "Route to advertise")
@@ -160,9 +160,9 @@ func newBgp(config gosnappi.Config) {
 			bgpIPv4Peer = bgpIPv4Interface.Peers().Add().SetName(bgpDeviceIPv4Interface.Name() + ".bgp.peer." + bgpPeerIP)
 		}
 
-		bgpIPv4Peer.SetAsNumber(bgpASN).SetAsType(bgpTypeEnum) // TODO update as_number_width for longer ASNs
-		bgpIPv4Peer.SetPeerAddress(bgpPeerIP)                  // TODO check if it is IPv6
-		if bgpRoute != "" {                                    // TODO IPv6
+		bgpIPv4Peer.SetAsNumber(int32(bgpASN)).SetAsType(bgpTypeEnum) // TODO update as_number_width for longer ASNs
+		bgpIPv4Peer.SetPeerAddress(bgpPeerIP)                         // TODO check if it is IPv6
+		if bgpRoute != "" {                                           // TODO IPv6
 			var bgpIPv4PeerRouteRange gosnappi.BgpV4RouteRange
 			for _, v := range bgpIPv4Peer.V4Routes().Items() {
 				if v.HasNextHopMode() && v.NextHopMode() == gosnappi.BgpV4RouteRangeNextHopMode.LOCAL_IP {

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -29,6 +29,8 @@ import (
 )
 
 var bgpDeviceName string // Device name to add BGP configuration to
+var bgpASN int32         // Autonomous System Number
+var bgpPeerIP string     // Peer IP address
 
 // bgpCmd represents the bgp command
 var bgpCmd = &cobra.Command{
@@ -61,7 +63,9 @@ func init() {
 	// is called directly, e.g.:
 	// bgpCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 
-	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to ")
+	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to")
+	bgpCmd.Flags().Int32VarP(&bgpASN, "asn", "a", 65535, "Autonomous System Number")
+	bgpCmd.Flags().StringVarP(&bgpPeerIP, "peer", "p", IPV4_DEFAULT_GW, "Peer IP address")
 }
 
 func addBgp() {
@@ -81,9 +85,12 @@ func newBgp(config gosnappi.Config) {
 	log.Debugf("Found matching device name: %s", bgpDeviceName)
 	bgpDeviceIPv4Interface := device.Ethernets().Items()[0].Ipv4Addresses().Items()[0]
 	if bgpDeviceIPv4Interface != nil { // TODO IPv6
-		log.Debugf("Adding BGP to the device's IPv4 interface: %s", bgpDeviceIPv4Interface.Address())
-		device.Bgp().SetRouterId(bgpDeviceIPv4Interface.Address()) // TODO parameterize router_id
-		device.Bgp().Ipv4Interfaces().Add().SetIpv4Name(bgpDeviceIPv4Interface.Name())
+		log.Debugf("Adding BGP to the device's IPv4 interface: %s with ASN %d and Peer IP %s", bgpDeviceIPv4Interface.Address(), bgpASN, bgpPeerIP)
+		device.Bgp().SetRouterId(bgpDeviceIPv4Interface.Address())                                         // TODO parameterize router_id
+		bgpIPv4Interface := device.Bgp().Ipv4Interfaces().Add().SetIpv4Name(bgpDeviceIPv4Interface.Name()) // TODO check if already exists
+		bgpIPv4Peer := bgpIPv4Interface.Peers().Add().SetName(bgpDeviceName + ".bgp4.peer[0]")             // TODO check if already exists
+		bgpIPv4Peer.SetAsNumber(bgpASN).SetAsType(gosnappi.BgpV4PeerAsType.EBGP)
+		bgpIPv4Peer.SetPeerAddress(bgpPeerIP) // TODO check if it is IPv6
 	}
 
 	// Print the OTG configuration constructed

--- a/cmd/bgp.go
+++ b/cmd/bgp.go
@@ -108,7 +108,7 @@ func init() {
 	bgpCmd.Flags().StringVarP(&bgpRouterID, "id", "", "", "Router ID (default is an IP address of the interface the BGP configuration is attached to)")
 	bgpCmd.Flags().StringVarP(&bgpDeviceName, "device", "d", DEVICE_NAME_1, "Device name to add BGP configuration to")
 	bgpCmd.Flags().Uint32VarP(&bgpASN, "asn", "", BGP_ASN_DEFAULT, "Autonomous System Number")
-	bgpCmd.Flags().StringVarP(&bgpPeerIP, "peer", "p", IPV4_DEFAULT_GW, "Peer IP address")
+	bgpCmd.Flags().StringVarP(&bgpPeerIP, "peer", "p", "", "Peer IP address (default is a GW address of the interface the BGP configuration is attached to)")
 	bgpCmd.Flags().StringVarP(&bgpType, "type", "t", string(gosnappi.BgpV4PeerAsType.EBGP), "BGP peering type: ebgp | ibgp")
 	bgpCmd.Flags().StringVarP(&bgpRoute, "route", "r", "", "Route to advertise")
 }
@@ -145,6 +145,10 @@ func newBgp(config gosnappi.Config) {
 		}
 		if bgpIPv4Interface == nil {
 			bgpIPv4Interface = device.Bgp().Ipv4Interfaces().Add().SetIpv4Name(bgpDeviceIPv4Interface.Name())
+		}
+		if bgpPeerIP == "" {
+			// use default gw from the linked interface as a default peer IP
+			bgpPeerIP = bgpDeviceIPv4Interface.Gateway()
 		}
 
 		var bgpIPv4Peer gosnappi.BgpV4Peer

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -71,15 +71,15 @@ const (
 // createCmd represents the create command
 var createCmd = &cobra.Command{
 	Use:   "create",
-	Short: "Create OTG configuration with the specified item",
+	Short: "Create an OTG configuration with the specified item",
 	Long: `
-Create OTG configuration with the specified item.
+Create an OTG configuration with the specified item.
 The configuration can be passed to stdin of either "otgen run" or "otgen add" command.
 
   For more information, go to https://github.com/open-traffic-generator/otgen
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		log.Error("You must specify an OTG object to create, one from the set: flow")
+		log.Error("You must specify an OTG configuration object to create, one of the following: flow | device")
 	},
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -81,6 +81,10 @@ The configuration can be passed to stdin of either "otgen run" or "otgen add" co
 	Run: func(cmd *cobra.Command, args []string) {
 		log.Error("You must specify an OTG configuration object to create, one of the following: flow | device")
 	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
+		return nil
+	},
 }
 
 func init() {

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -117,7 +117,7 @@ func addDevice() {
 	// Create a new API handle
 	api := gosnappi.NewApi()
 
-	// Read pre-existing traffic configuration from STDIN and then create a flow
+	// Read pre-existing traffic configuration from STDIN and then create a device
 	newDevice(readOtgStdin(api))
 }
 
@@ -143,7 +143,7 @@ func newDevice(config gosnappi.Config) {
 		SetGateway(deviceGWv4).
 		SetPrefix(devicePrefixv4)
 
-	// Print traffic configuration constructed
+	// Print the OTG configuration constructed
 	otgYaml, err := config.ToYaml()
 	if err != nil {
 		log.Fatal(err)

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -126,7 +126,7 @@ func newDevice(config gosnappi.Config) {
 	otgGetOrCreatePort(config, devicePort, devicePortLocation)
 
 	// Device name
-	device := config.Devices().Add().SetName(deviceName)
+	device := config.Devices().Add().SetName(deviceName) // TODO check if device already exists, and fail if so
 
 	// Device ethernets
 	deviceEth := device.Ethernets().Add().

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -54,6 +54,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
 		// set default MACs depending on Tx test port
 		switch devicePort {
 		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -40,9 +40,9 @@ var devicePrefixv4 int32      // Device IPv4 network prefix
 // deviceCmd represents the device command
 var deviceCmd = &cobra.Command{
 	Use:   "device",
-	Short: "New OTG device configuration",
+	Short: "Create a configuration for an Emulated Device",
 	Long: `
-New OTG device configuration.
+Create a configuration for an Emulated Device.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,
@@ -75,7 +75,6 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 }
 
 func init() {
-	rootCmd.AddCommand(deviceCmd)
 
 	// Here you will define your flags and configuration settings.
 

--- a/cmd/display.go
+++ b/cmd/display.go
@@ -60,6 +60,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
 		if displayType != TYPE_TABLE && displayType != TYPE_CHART {
 			return fmt.Errorf("unsupported display type: %s", displayType)
 		}

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -72,9 +72,9 @@ var flowMetricsTimestamps bool // Enable metrics timestamps
 // flowCmd represents the flow command
 var flowCmd = &cobra.Command{
 	Use:   "flow",
-	Short: "New OTG flow configuration",
+	Short: "Create a configuration for a Traffic Flow",
 	Long: `
-New OTG flow configuration.
+Create a configuration for a Traffic Flow.
 
 For more information, go to https://github.com/open-traffic-generator/otgen
 `,

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -26,7 +26,6 @@ import (
 	"strings"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -86,20 +85,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		}
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Logging level TODO call this via a function
-		switch logLevel {
-		case "err":
-			log.SetLevel(logrus.ErrorLevel)
-		case "warn":
-			log.SetLevel(logrus.WarnLevel)
-		case "info":
-			log.SetLevel(logrus.InfoLevel)
-		case "debug":
-			log.SetLevel(logrus.DebugLevel)
-		default:
-			log.Fatalf("Unsupported log level: %s", logLevel)
-		}
-		log.Debug("Parsing parameters...")
+		setLogLevel(cmd, logLevel)
 		// set values of Tx/Rx names and locations; src and dst MACs, IPs and TCP/UDP ports from defaults if not explicitly provided
 		// with optional --swap logic to easily reverse defaults between Tx and Rx sides
 		switch flowTxRxSwap { // Done: ports, MACs, IPs, TCP/UDP ports. TODO consider to swap only if both Tx and Rx are defaults

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -71,3 +71,32 @@ func init() {
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
 }
+
+func setLogLevel(cmd *cobra.Command, logLevel string) {
+
+	switch logLevel {
+	case "err":
+		log.SetLevel(logrus.ErrorLevel)
+	case "warn":
+		log.SetLevel(logrus.WarnLevel)
+	case "info":
+		log.SetLevel(logrus.InfoLevel)
+	case "debug":
+		log.SetLevel(logrus.DebugLevel)
+	default:
+		log.Fatalf("Unsupported log level: %s", logLevel)
+	}
+	log.Debugf("%s: log level set to %s", cmdFullName(cmd), logLevel)
+}
+
+func cmdFullName(cmd *cobra.Command) string {
+	var name string
+	if cmd == nil {
+		name = ""
+	} else if cmd.Parent() != nil {
+		name = cmdFullName(cmd.Parent()) + " " + cmd.Name()
+	} else {
+		name = cmd.Name()
+	}
+	return name
+}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,7 +31,6 @@ import (
 	"time"
 
 	"github.com/open-traffic-generator/snappi/gosnappi"
-	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 )
 
@@ -71,20 +70,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		stopProtocols(runTraffic(startProtocols(applyConfig(initOTG()))))
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		// Logging level
-		switch logLevel {
-		case "err":
-			log.SetLevel(logrus.ErrorLevel)
-		case "warn":
-			log.SetLevel(logrus.WarnLevel)
-		case "info":
-			log.SetLevel(logrus.InfoLevel)
-		case "debug":
-			log.SetLevel(logrus.DebugLevel)
-		default:
-			log.Fatalf("Unsupported log level: %s", logLevel)
-		}
-		log.Debug("Parsing parameters...")
+		setLogLevel(cmd, logLevel)
 
 		// Number of routes to receive to consider BGP is up
 		if len(otgRxBgpStr) > 1 && strings.HasSuffix(otgRxBgpStr, "x") {

--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -108,6 +108,7 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		transformStdInWithTemplate(template)
 	},
 	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
 		switch transformMetrics {
 		case METRIC_PORT:
 		case METRIC_FLOW:

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -51,6 +51,10 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		fmt.Printf("   date: %s\n", date)
 		fmt.Printf(" source: %s\n", repoUrl)
 	},
+	PreRunE: func(cmd *cobra.Command, args []string) error {
+		setLogLevel(cmd, logLevel)
+		return nil
+	},
 }
 
 func init() {

--- a/test/add/bgp-device.2route.yml
+++ b/test/add/bgp-device.2route.yml
@@ -8,7 +8,22 @@ devices:
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2
         peer_address: 192.0.2.2
-    router_id: 1.1.1.1
+        v4_routes:
+        - addresses:
+          - address: 198.51.100.0
+            count: 1
+            prefix: 24
+            step: 1
+          - address: 198.51.101.0
+            count: 1
+            prefix: 24
+            step: 1
+          name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2.rr4[0]
+          next_hop_address_type: ipv4
+          next_hop_ipv4_address: 0.0.0.0
+          next_hop_ipv6_address: ::0
+          next_hop_mode: local_ip
+    router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:
     - address: 192.0.2.1

--- a/test/add/bgp-device.2route.yml
+++ b/test/add/bgp-device.2route.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2

--- a/test/add/bgp-device.2route.yml
+++ b/test/add/bgp-device.2route.yml
@@ -36,5 +36,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.asn.yml
+++ b/test/add/bgp-device.asn.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 1111
         as_number_width: four
         as_type: ebgp
-        name: otg1.bgp4.peer[0]
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2
         peer_address: 192.0.2.2
     router_id: 192.0.2.1
   ethernets:

--- a/test/add/bgp-device.asn.yml
+++ b/test/add/bgp-device.asn.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.asn.yml
+++ b/test/add/bgp-device.asn.yml
@@ -1,25 +1,25 @@
 devices:
 - bgp:
     ipv4_interfaces:
-    - ipv4_name: r1.eth[0].ipv4[0]
+    - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 1111
         as_number_width: four
         as_type: ebgp
-        name: r1.bgp4.peer[0]
+        name: otg1.bgp4.peer[0]
         peer_address: 192.0.2.2
     router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:
     - address: 192.0.2.1
       gateway: 192.0.2.2
-      name: r1.eth[0].ipv4[0]
+      name: otg1.eth[0].ipv4[0]
       prefix: 24
     mac: 02:00:00:00:01:aa
     mtu: 1500
-    name: r1.eth[0]
+    name: otg1.eth[0]
     port_name: p1
-  name: r1
+  name: otg1
 ports:
 - location: localhost:5555
   name: p1

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 65535
         as_number_width: four
         as_type: ebgp
-        name: otg1.bgp4.peer[0]
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2
         peer_address: 192.0.2.2
     router_id: 192.0.2.1
   ethernets:

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -2,6 +2,12 @@ devices:
 - bgp:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
+      peers:
+      - as_number: 65535
+        as_number_width: four
+        as_type: ebgp
+        name: otg1.bgp4.peer[0]
+        peer_address: 192.0.2.2
     router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -1,0 +1,15 @@
+devices:
+- ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555
+  name: p1

--- a/test/add/bgp-device.defaults.yml
+++ b/test/add/bgp-device.defaults.yml
@@ -1,5 +1,7 @@
 devices:
 - bgp:
+    ipv4_interfaces:
+    - ipv4_name: otg1.eth[0].ipv4[0]
     router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:

--- a/test/add/bgp-device.id.yml
+++ b/test/add/bgp-device.id.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2

--- a/test/add/bgp-device.id.yml
+++ b/test/add/bgp-device.id.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.id.yml
+++ b/test/add/bgp-device.id.yml
@@ -1,0 +1,25 @@
+devices:
+- bgp:
+    ipv4_interfaces:
+    - ipv4_name: otg1.eth[0].ipv4[0]
+      peers:
+      - as_number: 65535
+        as_number_width: four
+        as_type: ebgp
+        name: otg1.bgp4.peer[0]
+        peer_address: 192.0.2.2
+    router_id: 1.1.1.1
+  ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555
+  name: p1

--- a/test/add/bgp-device.name.yml
+++ b/test/add/bgp-device.name.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: r1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.name.yml
+++ b/test/add/bgp-device.name.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 65535
         as_number_width: four
         as_type: ebgp
-        name: r1.bgp4.peer[0]
+        name: r1.eth[0].ipv4[0].bgp.peer.192.0.2.2
         peer_address: 192.0.2.2
     router_id: 192.0.2.1
   ethernets:

--- a/test/add/bgp-device.name.yml
+++ b/test/add/bgp-device.name.yml
@@ -5,13 +5,13 @@ devices:
   - ipv4_addresses:
     - address: 192.0.2.1
       gateway: 192.0.2.2
-      name: otg1.eth[0].ipv4[0]
+      name: r1.eth[0].ipv4[0]
       prefix: 24
     mac: 02:00:00:00:01:aa
     mtu: 1500
-    name: otg1.eth[0]
+    name: r1.eth[0]
     port_name: p1
-  name: otg1
+  name: r1
 ports:
 - location: localhost:5555
   name: p1

--- a/test/add/bgp-device.name.yml
+++ b/test/add/bgp-device.name.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: r1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: r1.eth[0].ipv4[0].bgp.peer.192.0.2.2

--- a/test/add/bgp-device.name.yml
+++ b/test/add/bgp-device.name.yml
@@ -1,5 +1,7 @@
 devices:
 - bgp:
+    ipv4_interfaces:
+    - ipv4_name: r1.eth[0].ipv4[0]
     router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:

--- a/test/add/bgp-device.peer-default-gw.yml
+++ b/test/add/bgp-device.peer-default-gw.yml
@@ -1,0 +1,25 @@
+devices:
+- bgp:
+    ipv4_interfaces:
+    - ipv4_name: otg1.eth[0].ipv4[0]
+      peers:
+      - as_number: 65534
+        as_number_width: four
+        as_type: ebgp
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.200
+        peer_address: 192.0.2.200
+    router_id: 192.0.2.1
+  ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.200
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555+localhost:50071
+  name: p1

--- a/test/add/bgp-device.peer.yml
+++ b/test/add/bgp-device.peer.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.200

--- a/test/add/bgp-device.peer.yml
+++ b/test/add/bgp-device.peer.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 65535
         as_number_width: four
         as_type: ebgp
-        name: otg1.bgp4.peer[0]
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.200
         peer_address: 192.0.2.200
     router_id: 192.0.2.1
   ethernets:

--- a/test/add/bgp-device.peer.yml
+++ b/test/add/bgp-device.peer.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.peer.yml
+++ b/test/add/bgp-device.peer.yml
@@ -1,25 +1,25 @@
 devices:
 - bgp:
     ipv4_interfaces:
-    - ipv4_name: r1.eth[0].ipv4[0]
+    - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
       - as_number: 65535
         as_number_width: four
         as_type: ebgp
-        name: r1.bgp4.peer[0]
-        peer_address: 192.0.2.2
+        name: otg1.bgp4.peer[0]
+        peer_address: 192.0.2.200
     router_id: 192.0.2.1
   ethernets:
   - ipv4_addresses:
     - address: 192.0.2.1
       gateway: 192.0.2.2
-      name: r1.eth[0].ipv4[0]
+      name: otg1.eth[0].ipv4[0]
       prefix: 24
     mac: 02:00:00:00:01:aa
     mtu: 1500
-    name: r1.eth[0]
+    name: otg1.eth[0]
     port_name: p1
-  name: r1
+  name: otg1
 ports:
 - location: localhost:5555
   name: p1

--- a/test/add/bgp-device.route.yml
+++ b/test/add/bgp-device.route.yml
@@ -1,0 +1,36 @@
+devices:
+- bgp:
+    ipv4_interfaces:
+    - ipv4_name: otg1.eth[0].ipv4[0]
+      peers:
+      - as_number: 65535
+        as_number_width: four
+        as_type: ebgp
+        name: otg1.bgp4.peer[0]
+        peer_address: 192.0.2.2
+        v4_routes:
+        - addresses:
+          - address: 198.51.100.0
+            count: 1
+            prefix: 24
+            step: 1
+          name: otg1.bgp4.peer[0].rr4
+          next_hop_address_type: ipv4
+          next_hop_ipv4_address: 0.0.0.0
+          next_hop_ipv6_address: ::0
+          next_hop_mode: local_ip
+    router_id: 192.0.2.1
+  ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555
+  name: p1

--- a/test/add/bgp-device.route.yml
+++ b/test/add/bgp-device.route.yml
@@ -32,5 +32,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.route.yml
+++ b/test/add/bgp-device.route.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ebgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2

--- a/test/add/bgp-device.route.yml
+++ b/test/add/bgp-device.route.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 65535
         as_number_width: four
         as_type: ebgp
-        name: otg1.bgp4.peer[0]
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2
         peer_address: 192.0.2.2
         v4_routes:
         - addresses:
@@ -14,7 +14,7 @@ devices:
             count: 1
             prefix: 24
             step: 1
-          name: otg1.bgp4.peer[0].rr4
+          name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.2.rr4[0]
           next_hop_address_type: ipv4
           next_hop_ipv4_address: 0.0.0.0
           next_hop_ipv6_address: ::0

--- a/test/add/bgp-device.type.yml
+++ b/test/add/bgp-device.type.yml
@@ -6,7 +6,7 @@ devices:
       - as_number: 65535
         as_number_width: four
         as_type: ibgp
-        name: otg1.bgp4.peer[0]
+        name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.200
         peer_address: 192.0.2.200
     router_id: 192.0.2.1
   ethernets:

--- a/test/add/bgp-device.type.yml
+++ b/test/add/bgp-device.type.yml
@@ -21,5 +21,5 @@ devices:
     port_name: p1
   name: otg1
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1

--- a/test/add/bgp-device.type.yml
+++ b/test/add/bgp-device.type.yml
@@ -1,0 +1,25 @@
+devices:
+- bgp:
+    ipv4_interfaces:
+    - ipv4_name: otg1.eth[0].ipv4[0]
+      peers:
+      - as_number: 65535
+        as_number_width: four
+        as_type: ibgp
+        name: otg1.bgp4.peer[0]
+        peer_address: 192.0.2.200
+    router_id: 192.0.2.1
+  ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555
+  name: p1

--- a/test/add/bgp-device.type.yml
+++ b/test/add/bgp-device.type.yml
@@ -3,7 +3,7 @@ devices:
     ipv4_interfaces:
     - ipv4_name: otg1.eth[0].ipv4[0]
       peers:
-      - as_number: 65535
+      - as_number: 65534
         as_number_width: four
         as_type: ibgp
         name: otg1.eth[0].ipv4[0].bgp.peer.192.0.2.200


### PR DESCRIPTION
```Shell
otgen add bgp                         # Add a BGP configuration to an Emulated Device
  [--device string]                   # Device name to add BGP configuration to (default "otg1")
  [--id]                              # Router ID (default is an IP address of the interface the BGP configuration is attached to)
  [--asn N]                           # Autonomous System Number (default 65534)
  [--peer x.x.x.x]                    # Peer IP address (default is a GW address of the interface the BGP configuration is attached to)
  [--type ebgp|ibgp]                  # BGP peering type: ebgp | ibgp (default "ebgp")
  [--route x.x.x.x/nn]                # Route to advertise
```
