### PR TITLE
Changes in defaults for `create flow` and `create device`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,33 +26,33 @@ tests-create-devices-flow:
 	@echo "#################################################################"
 	@echo "# Create two devices with flow between them"
 	@echo "#################################################################"
-	./otgen create device -n otg1 -p p1  | \
-	./otgen add    device -n otg2 -p p2  | \
+	./otgen create device -n otg1 -p p1 --location "localhost:5555+localhost:50071" | \
+	./otgen add    device -n otg2 -p p2 --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg1 --rx otg2 | \
 	diff test/create/flow-device.defaults.yml -
 
-	./otgen create device -n otg1 -p p1  | \
-	./otgen add    device -n otg2 -p p2  | \
+	./otgen create device -n otg1 -p p1 --location "localhost:5555+localhost:50071" | \
+	./otgen add    device -n otg2 -p p2 --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg2 --rx otg1 --swap | \
 	diff test/create/flow-device.swap.yml -
 
-	OTG_FLOW_SMAC_P1="02:11:11:00:01:aa" ./otgen create device -n otg1 -p p1  | \
-	OTG_FLOW_SMAC_P2="02:11:11:00:02:aa" ./otgen add    device -n otg2 -p p2  | \
+	OTG_FLOW_SMAC_P1="02:11:11:00:01:aa" ./otgen create device -n otg1 -p p1 --location "localhost:5555+localhost:50071" | \
+	OTG_FLOW_SMAC_P2="02:11:11:00:02:aa" ./otgen add    device -n otg2 -p p2 --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg1 --rx otg2 | \
 	diff test/create/flow-device.mac.env.yml -
 
-	./otgen create device -n otg1 -p p1  --mac "02:11:11:00:01:aa" | \
-	./otgen add    device -n otg2 -p p2  --mac "02:11:11:00:02:aa" | \
+	./otgen create device -n otg1 -p p1  --mac "02:11:11:00:01:aa" --location "localhost:5555+localhost:50071" | \
+	./otgen add    device -n otg2 -p p2  --mac "02:11:11:00:02:aa" --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg1 --rx otg2 | \
 	diff test/create/flow-device.mac.yml -
 
-	./otgen create device -n otg1 -p p1  --mac "02:11:11:00:01:aa" | \
-	./otgen add    device -n otg2 -p p2  --mac "02:11:11:00:02:aa" | \
+	./otgen create device -n otg1 -p p1  --mac "02:11:11:00:01:aa" --location "localhost:5555+localhost:50071" | \
+	./otgen add    device -n otg2 -p p2  --mac "02:11:11:00:02:aa" --location "localhost:5556+localhost:50072" | \
 	./otgen add flow --tx otg2 --rx otg1 --swap | \
 	diff test/create/flow-device.mac.swap.yml -
 
-	./otgen create device -n otg1 -p p1  | \
-	./otgen add    device -n otg2 -p p2  | \
+	./otgen create device -n otg1 -p p1 | \
+	./otgen add    device -n otg2 -p p2 | \
 	./otgen add flow --tx otg1 --rx otg2 --smac "02:11:11:00:01:aa" --dmac "02:11:11:00:02:aa" | \
 	diff test/create/flow-device.flow.mac.yml -
 

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,16 @@ tests-create-flow-raw:
 	./otgen create flow --smac "02:11:11:00:01:aa" --dmac "02:11:11:00:02:aa" --swap | diff test/create/flow.mac.swap.yml -
 	@echo
 
+tests-create-device:
+	@echo "#################################################################"
+	@echo "# Create a device"
+	@echo "#################################################################"
+	./otgen create device | \
+	diff test/create/device.defaults.yml -
+
+	./otgen create device -p p2 | \
+	diff test/create/device.port.yml -
+
 tests-create-devices-flow:
 	@echo "#################################################################"
 	@echo "# Create two devices with flow between them"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ otgen create flow                     # Create a configuration for a Traffic Flo
   [--ipv6 ]                           # IP version 6
   [--proto icmp | tcp | udp]          # IP transport protocol
   [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address. For device-bound flows, default value is copied from the Tx device
-  [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address. For device-bound flows, use auto to enable ARP for IPv4 / ND for IPv6
+  [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address. For device-bound flows, default value "auto" enables ARP for IPv4 / ND for IPv6
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address
   [--sport N]                         # Source TCP or UDP port. If not specified, incrementing source port numbers would be used for each new packet

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ otgen create flow                     # Create a configuration for a Traffic Flo
   [--ipv4 ]                           # IP version 4 (default)
   [--ipv6 ]                           # IP version 6
   [--proto icmp | tcp | udp]          # IP transport protocol
-  [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address
+  [--smac xx.xx.xx.xx.xx.xx]          # Source MAC address. For device-bound flows, default value is copied from the Tx device
   [--dmac xx.xx.xx.xx.xx.xx]          # Destination MAC address. For device-bound flows, use auto to enable ARP for IPv4 / ND for IPv6
   [--src x.x.x.x]                     # Source IP address
   [--dst x.x.x.x]                     # Destination IP address

--- a/cmd/device.go
+++ b/cmd/device.go
@@ -58,17 +58,21 @@ For more information, go to https://github.com/open-traffic-generator/otgen
 		// set default MACs depending on Tx test port
 		switch devicePort {
 		case PORT_NAME_RX: // swap default SRC and DST MACs. TODO use --swap parameter instead to do this explicitly
+			if devicePortLocation == "" {
+				devicePortLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)), PORT_LOCATION_RX)
+			}
+
 			if deviceMac == "" {
 				deviceMac = envSubstOrDefault(MAC_SRC_RX, MAC_DEFAULT_DST)
 			}
 		default: // PORT_NAME_TX
+			if devicePortLocation == "" {
+				devicePortLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)), PORT_LOCATION_TX)
+			}
+
 			if deviceMac == "" {
 				deviceMac = envSubstOrDefault(MAC_SRC_TX, MAC_DEFAULT_SRC)
 			}
-		}
-
-		if devicePortLocation == "" {
-			devicePortLocation = envSubstOrDefault(stringFromTemplate(PORT_LOCATION_TEMPLATE, "NAME", strings.ToUpper(devicePort)), PORT_LOCATION_TX)
 		}
 
 		return nil

--- a/cmd/flow.go
+++ b/cmd/flow.go
@@ -224,7 +224,7 @@ func init() {
 	flowCmd.Flags().StringVarP(&flowRxLocation, "rxl", "", "", fmt.Sprintf("Test port location string for Rx (default \"%s\")", PORT_LOCATION_RX))
 
 	flowCmd.Flags().StringVarP(&flowSrcMac, "smac", "S", envSubstOrDefault(MAC_SRC_TX, MAC_DEFAULT_SRC), "Source MAC address. For device-bound flows, default value is copied from the Tx device")
-	flowCmd.Flags().StringVarP(&flowDstMac, "dmac", "D", envSubstOrDefault(MAC_DST_TX, MAC_DEFAULT_DST), "Destination MAC address. For device-bound flows, use \"auto\" to enable ARP for IPv4 / ND for IPv6")
+	flowCmd.Flags().StringVarP(&flowDstMac, "dmac", "D", envSubstOrDefault(MAC_DST_TX, MAC_DEFAULT_DST), "Destination MAC address. For device-bound flows, default value \"auto\" enables ARP for IPv4 / ND for IPv6")
 
 	flowCmd.Flags().BoolVarP(&flowIPv4, "ipv4", "4", true, "IP Version 4")
 	flowCmd.Flags().BoolVarP(&flowIPv6, "ipv6", "6", false, "IP Version 6")
@@ -356,7 +356,8 @@ func newFlow(config gosnappi.Config) {
 				eth.Dst().SetValue(flowDstMac)
 			}
 		} else {
-			eth.Dst().SetValue(deviceRx.Ethernets().Items()[0].Mac())
+			log.Debugf("Device-bound flow %s will use \"auto\" mode for the destination MAC by default", flowName)
+			eth.Dst().SetChoice("auto")
 		}
 	} else {
 		portRx := otgGetOrCreatePort(config, flowRxPort, flowRxLocation)

--- a/test/create/device.defaults.yml
+++ b/test/create/device.defaults.yml
@@ -1,0 +1,15 @@
+devices:
+- ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:01:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p1
+  name: otg1
+ports:
+- location: localhost:5555
+  name: p1

--- a/test/create/device.port.yml
+++ b/test/create/device.port.yml
@@ -1,0 +1,15 @@
+devices:
+- ethernets:
+  - ipv4_addresses:
+    - address: 192.0.2.1
+      gateway: 192.0.2.2
+      name: otg1.eth[0].ipv4[0]
+      prefix: 24
+    mac: 02:00:00:00:02:aa
+    mtu: 1500
+    name: otg1.eth[0]
+    port_name: p2
+  name: otg1
+ports:
+- location: localhost:5556
+  name: p2

--- a/test/create/flow-device.defaults.yml
+++ b/test/create/flow-device.defaults.yml
@@ -36,8 +36,8 @@ flows:
   - choice: ethernet
     ethernet:
       dst:
-        choice: value
-        value: 02:00:00:00:02:aa
+        auto: "00:00:00:00:00:00"
+        choice: auto
       src:
         choice: value
         value: 02:00:00:00:01:aa
@@ -69,7 +69,7 @@ flows:
       tx_names:
       - otg1.eth[0].ipv4[0]
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1
-- location: localhost:5555
+- location: localhost:5556+localhost:50072
   name: p2

--- a/test/create/flow-device.defaults.yml
+++ b/test/create/flow-device.defaults.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         choice: value
         value: 02:00:00:00:02:aa
+      src:
+        choice: value
+        value: 02:00:00:00:01:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.flow.mac.yml
+++ b/test/create/flow-device.flow.mac.yml
@@ -71,5 +71,5 @@ flows:
 ports:
 - location: localhost:5555
   name: p1
-- location: localhost:5555
+- location: localhost:5556
   name: p2

--- a/test/create/flow-device.mac.auto.yml
+++ b/test/create/flow-device.mac.auto.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         auto: "00:00:00:00:00:00"
         choice: auto
+      src:
+        choice: value
+        value: 02:00:00:00:01:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.mac.env.yml
+++ b/test/create/flow-device.mac.env.yml
@@ -36,8 +36,8 @@ flows:
   - choice: ethernet
     ethernet:
       dst:
-        choice: value
-        value: 02:11:11:00:02:aa
+        auto: "00:00:00:00:00:00"
+        choice: auto
       src:
         choice: value
         value: 02:11:11:00:01:aa
@@ -69,7 +69,7 @@ flows:
       tx_names:
       - otg1.eth[0].ipv4[0]
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1
-- location: localhost:5555
+- location: localhost:5556+localhost:50072
   name: p2

--- a/test/create/flow-device.mac.env.yml
+++ b/test/create/flow-device.mac.env.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         choice: value
         value: 02:11:11:00:02:aa
+      src:
+        choice: value
+        value: 02:11:11:00:01:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.mac.swap.yml
+++ b/test/create/flow-device.mac.swap.yml
@@ -36,8 +36,8 @@ flows:
   - choice: ethernet
     ethernet:
       dst:
-        choice: value
-        value: 02:11:11:00:01:aa
+        auto: "00:00:00:00:00:00"
+        choice: auto
       src:
         choice: value
         value: 02:11:11:00:02:aa
@@ -69,7 +69,7 @@ flows:
       tx_names:
       - otg2.eth[0].ipv4[0]
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1
-- location: localhost:5555
+- location: localhost:5556+localhost:50072
   name: p2

--- a/test/create/flow-device.mac.swap.yml
+++ b/test/create/flow-device.mac.swap.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         choice: value
         value: 02:11:11:00:01:aa
+      src:
+        choice: value
+        value: 02:11:11:00:02:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.mac.yml
+++ b/test/create/flow-device.mac.yml
@@ -36,8 +36,8 @@ flows:
   - choice: ethernet
     ethernet:
       dst:
-        choice: value
-        value: 02:11:11:00:02:aa
+        auto: "00:00:00:00:00:00"
+        choice: auto
       src:
         choice: value
         value: 02:11:11:00:01:aa
@@ -69,7 +69,7 @@ flows:
       tx_names:
       - otg1.eth[0].ipv4[0]
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1
-- location: localhost:5555
+- location: localhost:5556+localhost:50072
   name: p2

--- a/test/create/flow-device.mac.yml
+++ b/test/create/flow-device.mac.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         choice: value
         value: 02:11:11:00:02:aa
+      src:
+        choice: value
+        value: 02:11:11:00:01:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.swap.yml
+++ b/test/create/flow-device.swap.yml
@@ -38,6 +38,9 @@ flows:
       dst:
         choice: value
         value: 02:00:00:00:01:aa
+      src:
+        choice: value
+        value: 02:00:00:00:02:aa
   - choice: ipv4
     ipv4:
       dst:

--- a/test/create/flow-device.swap.yml
+++ b/test/create/flow-device.swap.yml
@@ -36,8 +36,8 @@ flows:
   - choice: ethernet
     ethernet:
       dst:
-        choice: value
-        value: 02:00:00:00:01:aa
+        auto: "00:00:00:00:00:00"
+        choice: auto
       src:
         choice: value
         value: 02:00:00:00:02:aa
@@ -69,7 +69,7 @@ flows:
       tx_names:
       - otg2.eth[0].ipv4[0]
 ports:
-- location: localhost:5555
+- location: localhost:5555+localhost:50071
   name: p1
-- location: localhost:5555
+- location: localhost:5556+localhost:50072
   name: p2


### PR DESCRIPTION
- default value for source MAC for device-bound flows is copied from the Tx device (fixes #34)
- default mode for destination MAC for device-bound flows is changed to "auto" (closes #35)
- default location string for devices bound to port `p2` is changed fo "localhost:5556" (fixes #33)