### PR TITLE
`run`: make starting and/or stopping protocols optional

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "test/otg-examples"]
 	path = test/otg-examples
 	url = https://github.com/open-traffic-generator/otg-examples.git
+	update = merge

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,9 @@ build:
 install: otgen
 	cp otgen /usr/local/bin/
 
+update-submodules:
+	git submodule update --remote
+
 tests: tests-create tests-create-devices-flow tests-add-bgp
 
 tests-create: tests-create-flow-raw

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ get:
 build:
 	go build -ldflags="-X 'github.com/open-traffic-generator/otgen/cmd.version=v0.0.0-${USER}'"
 
+install: otgen
+	cp otgen /usr/local/bin/
+
 tests: tests-create tests-create-devices-flow tests-add-bgp
 
 tests-create: tests-create-flow-raw

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ otgen run
   [--interval 0.5s]                   # Interval to pull OTG metrics. Valid time units are 'ms', 's', 'm', 'h'. Example: 1s (default 0.5s)
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)
   [--timeout 120]                     # Maximum total run time, including protocols convergence and running traffic
+  [--protocols auto|ignore|keep]      # Protocols control mode: auto - detect, start and stop; ignore - do not detect, start or stop; keep - detect, start but do not stop
 ````
 
 ### `transform`


### PR DESCRIPTION
`otgen run` protocols control mode flag:

```
--protocols auto|ignore|keep     # Protocols control mode: auto - detect, start and stop; ignore - do not detect, start or stop; keep - detect, start but do not stop
```