### PR TITLE
Documentation updates for otg.dev

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -53,65 +53,65 @@ See `tests` in [`Makefile`](Makefile)
 
    - Port metrics
 
-```Shell
-cat test/transform/port_metrics.json | ./otgen transform                   | diff test/transform/port_metrics_passthrough.json -
-cat test/transform/port_metrics.json | ./otgen transform -m port           | diff test/transform/port_metrics_frames.json -
-cat test/transform/port_metrics.json | ./otgen transform -m port -c frames | diff test/transform/port_metrics_frames.json -
-cat test/transform/port_metrics.json | ./otgen transform -m port -c bytes  | diff test/transform/port_metrics_bytes.json -
-cat test/transform/port_metrics.json | ./otgen transform -m port -c pps    | diff test/transform/port_metrics_frame_rate.json -
-cat test/transform/port_metrics.json | ./otgen transform -m port -c tput   | diff test/transform/port_metrics_byte_rate.json -
-```
+   ```Shell
+   cat test/transform/port_metrics.json | ./otgen transform                   | diff test/transform/port_metrics_passthrough.json -
+   cat test/transform/port_metrics.json | ./otgen transform -m port           | diff test/transform/port_metrics_frames.json -
+   cat test/transform/port_metrics.json | ./otgen transform -m port -c frames | diff test/transform/port_metrics_frames.json -
+   cat test/transform/port_metrics.json | ./otgen transform -m port -c bytes  | diff test/transform/port_metrics_bytes.json -
+   cat test/transform/port_metrics.json | ./otgen transform -m port -c pps    | diff test/transform/port_metrics_frame_rate.json -
+   cat test/transform/port_metrics.json | ./otgen transform -m port -c tput   | diff test/transform/port_metrics_byte_rate.json -
+   ```
 
    - Flow metrics
 
-```Shell
-cat test/transform/flow_metrics.json | ./otgen transform                   | diff test/transform/flow_metrics_passthrough.json -
-cat test/transform/flow_metrics.json | ./otgen transform -m flow           | diff test/transform/flow_metrics_frames.json -
-cat test/transform/flow_metrics.json | ./otgen transform -m flow -c frames | diff test/transform/flow_metrics_frames.json -
-cat test/transform/flow_metrics.json | ./otgen transform -m flow -c bytes  | diff test/transform/flow_metrics_bytes.json -
-cat test/transform/flow_metrics.json | ./otgen transform -m flow -c pps    | diff test/transform/flow_metrics_frame_rate.json -
-```
+   ```Shell
+   cat test/transform/flow_metrics.json | ./otgen transform                   | diff test/transform/flow_metrics_passthrough.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -m flow           | diff test/transform/flow_metrics_frames.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c frames | diff test/transform/flow_metrics_frames.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c bytes  | diff test/transform/flow_metrics_bytes.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c pps    | diff test/transform/flow_metrics_frame_rate.json -
+   ```
 
 2. Templates - JSON
 
    - Port metrics
 
-```Shell
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/port_metrics_passthrough.json -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrames.tmpl    | diff test/transform/port_metrics_frames.json -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytes.tmpl     | diff test/transform/port_metrics_bytes.json -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRate.tmpl | diff test/transform/port_metrics_frame_rate.json -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRate.tmpl  | diff test/transform/port_metrics_byte_rate.json -
-````
+   ```Shell
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/port_metrics_passthrough.json -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrames.tmpl    | diff test/transform/port_metrics_frames.json -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytes.tmpl     | diff test/transform/port_metrics_bytes.json -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRate.tmpl | diff test/transform/port_metrics_frame_rate.json -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRate.tmpl  | diff test/transform/port_metrics_byte_rate.json -
+   ```
 
    - Flow metrics
 
-```Shell
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/flow_metrics_passthrough.json -
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrames.tmpl    | diff test/transform/flow_metrics_frames.json -
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytes.tmpl     | diff test/transform/flow_metrics_bytes.json -
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRate.tmpl | diff test/transform/flow_metrics_frame_rate.json -
-```
+   ```Shell
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/flow_metrics_passthrough.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrames.tmpl    | diff test/transform/flow_metrics_frames.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytes.tmpl     | diff test/transform/flow_metrics_bytes.json -
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRate.tmpl | diff test/transform/flow_metrics_frame_rate.json -
+   ```
 
 
 3. Templates - Tables
 
    - Port metrics
 
-```Shell
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFramesTable.tmpl    | diff test/transform/port_metrics_frames_table.txt -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytesTable.tmpl     | diff test/transform/port_metrics_bytes_table.txt -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRateTable.tmpl | diff test/transform/port_metrics_frame_rate_table.txt -
-cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRateTable.tmpl  | diff test/transform/port_metrics_byte_rate_table.txt -
-````
+   ```Shell
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFramesTable.tmpl    | diff test/transform/port_metrics_frames_table.txt -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytesTable.tmpl     | diff test/transform/port_metrics_bytes_table.txt -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRateTable.tmpl | diff test/transform/port_metrics_frame_rate_table.txt -
+   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRateTable.tmpl  | diff test/transform/port_metrics_byte_rate_table.txt -
+   ```
 
    - Flow metrics
 
-```Shell
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFramesTable.tmpl    | diff test/transform/flow_metrics_frames_table.txt -
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytesTable.tmpl     | diff test/transform/flow_metrics_bytes_table.txt -
-cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRateTable.tmpl | diff test/transform/flow_metrics_frame_rate_table.txt -
-```
+   ```Shell
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFramesTable.tmpl    | diff test/transform/flow_metrics_frames_table.txt -
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytesTable.tmpl     | diff test/transform/flow_metrics_bytes_table.txt -
+   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRateTable.tmpl | diff test/transform/flow_metrics_frame_rate_table.txt -
+   ```
 
 4. Full pipe with port metrics
 
@@ -125,26 +125,26 @@ Currently, only for visual inspection
 
 1. Charts
 
-```Shell
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode chart --type line
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode chart --type line
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode chart --type line
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode chart --type line
+   ```Shell
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode chart --type line
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode chart --type line
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode chart --type line
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode chart --type line
 
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode chart --type line
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode chart --type line
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode chart --type line
-```
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode chart --type line
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode chart --type line
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode chart --type line
+   ```
 
 2. Table
 
-```Shell
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode table
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode table
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode table
-cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode table
+   ```Shell
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode table
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode table
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode table
+   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode table
 
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode table
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode table
-cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode table
-```
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode table
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode table
+   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode table
+   ```

--- a/BUILD.md
+++ b/BUILD.md
@@ -51,73 +51,72 @@ See `tests` in [`Makefile`](Makefile)
 
 1. Parameters
 
-   - Port metrics
+    - Port metrics
 
-   ```Shell
-   cat test/transform/port_metrics.json | ./otgen transform                   | diff test/transform/port_metrics_passthrough.json -
-   cat test/transform/port_metrics.json | ./otgen transform -m port           | diff test/transform/port_metrics_frames.json -
-   cat test/transform/port_metrics.json | ./otgen transform -m port -c frames | diff test/transform/port_metrics_frames.json -
-   cat test/transform/port_metrics.json | ./otgen transform -m port -c bytes  | diff test/transform/port_metrics_bytes.json -
-   cat test/transform/port_metrics.json | ./otgen transform -m port -c pps    | diff test/transform/port_metrics_frame_rate.json -
-   cat test/transform/port_metrics.json | ./otgen transform -m port -c tput   | diff test/transform/port_metrics_byte_rate.json -
-   ```
+        ```Shell
+        cat test/transform/port_metrics.json | ./otgen transform                   | diff test/transform/port_metrics_passthrough.json -
+        cat test/transform/port_metrics.json | ./otgen transform -m port           | diff test/transform/port_metrics_frames.json -
+        cat test/transform/port_metrics.json | ./otgen transform -m port -c frames | diff test/transform/port_metrics_frames.json -
+        cat test/transform/port_metrics.json | ./otgen transform -m port -c bytes  | diff test/transform/port_metrics_bytes.json -
+        cat test/transform/port_metrics.json | ./otgen transform -m port -c pps    | diff test/transform/port_metrics_frame_rate.json -
+        cat test/transform/port_metrics.json | ./otgen transform -m port -c tput   | diff test/transform/port_metrics_byte_rate.json -
+        ```
 
-   - Flow metrics
+    - Flow metrics
 
-   ```Shell
-   cat test/transform/flow_metrics.json | ./otgen transform                   | diff test/transform/flow_metrics_passthrough.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -m flow           | diff test/transform/flow_metrics_frames.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c frames | diff test/transform/flow_metrics_frames.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c bytes  | diff test/transform/flow_metrics_bytes.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -m flow -c pps    | diff test/transform/flow_metrics_frame_rate.json -
-   ```
+        ```Shell
+        cat test/transform/flow_metrics.json | ./otgen transform                   | diff test/transform/flow_metrics_passthrough.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -m flow           | diff test/transform/flow_metrics_frames.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -m flow -c frames | diff test/transform/flow_metrics_frames.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -m flow -c bytes  | diff test/transform/flow_metrics_bytes.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -m flow -c pps    | diff test/transform/flow_metrics_frame_rate.json -
+        ```
 
 2. Templates - JSON
 
-   - Port metrics
+    - Port metrics
 
-   ```Shell
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/port_metrics_passthrough.json -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrames.tmpl    | diff test/transform/port_metrics_frames.json -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytes.tmpl     | diff test/transform/port_metrics_bytes.json -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRate.tmpl | diff test/transform/port_metrics_frame_rate.json -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRate.tmpl  | diff test/transform/port_metrics_byte_rate.json -
-   ```
+        ```Shell
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/port_metrics_passthrough.json -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrames.tmpl    | diff test/transform/port_metrics_frames.json -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytes.tmpl     | diff test/transform/port_metrics_bytes.json -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRate.tmpl | diff test/transform/port_metrics_frame_rate.json -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRate.tmpl  | diff test/transform/port_metrics_byte_rate.json -
+        ```
 
-   - Flow metrics
+    - Flow metrics
 
-   ```Shell
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/flow_metrics_passthrough.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrames.tmpl    | diff test/transform/flow_metrics_frames.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytes.tmpl     | diff test/transform/flow_metrics_bytes.json -
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRate.tmpl | diff test/transform/flow_metrics_frame_rate.json -
-   ```
-
+        ```Shell
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformPassThrough.tmpl   | diff test/transform/flow_metrics_passthrough.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrames.tmpl    | diff test/transform/flow_metrics_frames.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytes.tmpl     | diff test/transform/flow_metrics_bytes.json -
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRate.tmpl | diff test/transform/flow_metrics_frame_rate.json -
+        ```
 
 3. Templates - Tables
 
-   - Port metrics
+    - Port metrics
 
-   ```Shell
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFramesTable.tmpl    | diff test/transform/port_metrics_frames_table.txt -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytesTable.tmpl     | diff test/transform/port_metrics_bytes_table.txt -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRateTable.tmpl | diff test/transform/port_metrics_frame_rate_table.txt -
-   cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRateTable.tmpl  | diff test/transform/port_metrics_byte_rate_table.txt -
-   ```
+        ```Shell
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFramesTable.tmpl    | diff test/transform/port_metrics_frames_table.txt -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortBytesTable.tmpl     | diff test/transform/port_metrics_bytes_table.txt -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortFrameRateTable.tmpl | diff test/transform/port_metrics_frame_rate_table.txt -
+        cat test/transform/port_metrics.json | ./otgen transform -f templates/transformPortByteRateTable.tmpl  | diff test/transform/port_metrics_byte_rate_table.txt -
+        ```
 
-   - Flow metrics
+    - Flow metrics
 
-   ```Shell
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFramesTable.tmpl    | diff test/transform/flow_metrics_frames_table.txt -
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytesTable.tmpl     | diff test/transform/flow_metrics_bytes_table.txt -
-   cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRateTable.tmpl | diff test/transform/flow_metrics_frame_rate_table.txt -
-   ```
+        ```Shell
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFramesTable.tmpl    | diff test/transform/flow_metrics_frames_table.txt -
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowBytesTable.tmpl     | diff test/transform/flow_metrics_bytes_table.txt -
+        cat test/transform/flow_metrics.json | ./otgen transform -f templates/transformFlowFrameRateTable.tmpl | diff test/transform/flow_metrics_frame_rate_table.txt -
+        ```
 
 4. Full pipe with port metrics
 
-```Shell
-cat ../otg.b2b.json | ./otgen run -k 2>/dev/null | ./otgen transform -m port
-```
+    ```Shell
+    cat ../otg.b2b.json | ./otgen run -k 2>/dev/null | ./otgen transform -m port
+    ```
 
 ### `display`
 
@@ -125,26 +124,26 @@ Currently, only for visual inspection
 
 1. Charts
 
-   ```Shell
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode chart --type line
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode chart --type line
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode chart --type line
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode chart --type line
+    ```Shell
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode chart --type line
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode chart --type line
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode chart --type line
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode chart --type line
 
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode chart --type line
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode chart --type line
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode chart --type line
-   ```
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode chart --type line
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode chart --type line
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode chart --type line
+    ```
 
 2. Table
 
-   ```Shell
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode table
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode table
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode table
-   cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode table
+    ```Shell
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c frames | ./otgen display --mode table
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c bytes  | ./otgen display --mode table
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c pps    | ./otgen display --mode table
+    cat test/transform/port_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m port -c tput   | ./otgen display --mode table
 
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode table
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode table
-   cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode table
-   ```
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c frames | ./otgen display --mode table
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c bytes  | ./otgen display --mode table
+    cat test/transform/flow_metrics.json | ./test/transform/delay.sh 0.5 | ./otgen transform -m flow -c pps    | ./otgen display --mode table
+    ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ otgen transform --metrics flow --counters frames | \
 otgen display --mode table
 ```
 
+Port locations are read from `ENV:OTG_LOCATION_P1` and `ENV:OTG_LOCATION_P2`.
+
+See [Environmental variables](#environmental-variables) section for more options.
+
+## Installation
+
+`otgen` is available as [source code](https://github.com/open-traffic-generator/otgen) with [build instructions](https://github.com/open-traffic-generator/otgen/blob/main/BUILD.md), as well as [precompiled binaries](https://github.com/open-traffic-generator/otgen/releases).
+
 ## Command reference
 
 ### Global options

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 ## How to use
 
 The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API interaction into multiple stages with output of one feeding to the next. This way, each individual stage can be:
+
 * easily parameterized, 
 * individually re-used,
 * when needed, substituted by a custom implementation
@@ -18,7 +19,7 @@ otgen add flow -n f2 -s 2.2.2.2 -d 1.1.1.1 --sport 80 --dport 1024 --tx p2 --rx 
 otgen run --metrics flow | \
 otgen transform --metrics flow --counters frames | \
 otgen display --mode table
-````
+```
 
 ## Command reference
 
@@ -104,7 +105,7 @@ otgen run
   [--xeta 2]                          # How long to wait before forcing traffic to stop. In multiples of ETA. Example: 1.5 (default 2)
   [--timeout 120]                     # Maximum total run time, including protocols convergence and running traffic
   [--protocols auto|ignore|keep]      # Protocols control mode: auto - detect, start and stop; ignore - do not detect, start or stop; keep - detect, start but do not stop
-````
+```
 
 ### `transform`
 
@@ -121,7 +122,7 @@ otgen transform
                                       #   "pps" for frame rate, in packets per second
                                       #   "tput" for throughput, in bytes per second (PortMetrics only)
   [--file template.tmpl]              # Go template file. If not provided, built-in templates will be used based on provided parameters
-````
+```
 
 ### `display`
 
@@ -131,7 +132,7 @@ Displays metrics of a running test as charts or a table.
 otgen display
   [--mode chart|table]               # Display type to show metrics as
   [--type line]                      # Type of the chart displayed. Currently, only line charts are supported.
-````
+```
 
 ### `help`
 
@@ -139,7 +140,7 @@ For built-in help, use
 
 ```Shell
 otgen run --help
-````
+```
 
 ### `version`
 
@@ -147,7 +148,7 @@ To check `otgen` version you have, use
 
 ```Shell
 otgen version
-````
+```
 
 ## Environmental variables
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 
 ## How to use
 
-The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API interaction into multiple stages with output of one feeding to the next. This way, each individual stage can be:
+The idea behind `otgen` is to leverage shell pipe capabilities to break OTG API interactions into multiple stages with output of one feeding to the next. This way, each individual stage can be:
 
 * easily parameterized, 
 * individually re-used,
 * when needed, substituted by a custom implementation
 
-The pipe workflow on `otgen` looks the following:
+The shell pipe workflow on `otgen` looks the following:
 
 ```Shell
 otgen create flow -s 1.1.1.1 -d 2.2.2.2 -p 80 --rate 1000 | \
@@ -73,6 +73,15 @@ otgen create device                   # Create a configuration for an Emulated D
 ```
 
 ### `add bgp`
+
+Adds a BGP router to an emulated device in the existing OTG configuration. Typical usage:
+
+```Shell
+otgen create device --name r1 | \
+otgen add bgp --device r1 --route 203.0.113.0/24
+```
+
+Available parameters:
 
 ```Shell
 otgen add bgp                         # Add a BGP configuration to an Emulated Device


### PR DESCRIPTION
Fixes for mkdocs to let otgen repo docs to be added to otg.dev as a submodule