### PR TITLE
gosnappi v0.12.6 + uint64 counter in transform

### DIFF
--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build otgen
         run: cd ../../.. && go get && go mod tidy && go build && sudo mv otgen /usr/local/bin/otgen
       - name: Setup testbed
-        run:  make install network deploy
+        run:  make install network deploy && sleep 5
       - name: Test1 RUN with STDIN YAML
         run:  cat otg.yml | otgen --log debug run -k
       - name: Test2 RUN with --api

--- a/.github/workflows/systest.yml
+++ b/.github/workflows/systest.yml
@@ -62,12 +62,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.ENV_GITHUB_USER }}
-          password: ${{ secrets.ENV_GITHUB_PAT }}
       - name: Set up Go
         uses: actions/setup-go@v4
         with:

--- a/cmd/transform.go
+++ b/cmd/transform.go
@@ -172,7 +172,7 @@ func transformMetricsResponse(mr gosnappi.MetricsResponse, tmpl string) {
 				}
 				return string(j)
 			},
-			"counterPrintf": func(f string, c int64) string {
+			"counterPrintf": func(f string, c uint64) string {
 				return fmt.Sprintf(f, c)
 			},
 			"ratePrintf": func(f string, c float32) string {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.18.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/open-traffic-generator/snappi/gosnappi v0.12.6
+	github.com/open-traffic-generator/snappi/gosnappi v0.13.0
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	google.golang.org/protobuf v1.31.0
@@ -30,6 +30,6 @@ require (
 	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
-	google.golang.org/grpc v1.58.2 // indirect
+	google.golang.org/grpc v1.58.3 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.18.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/open-traffic-generator/snappi/gosnappi v0.12.3
+	github.com/open-traffic-generator/snappi/gosnappi v0.12.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	google.golang.org/protobuf v1.31.0
@@ -30,6 +30,6 @@ require (
 	golang.org/x/term v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230711160842-782d3b101e98 // indirect
-	google.golang.org/grpc v1.58.0 // indirect
+	google.golang.org/grpc v1.58.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/lucasb-eyer/go-colorful v1.2.0
 	github.com/mum4k/termdash v0.18.0
 	github.com/olekukonko/tablewriter v0.0.5
-	github.com/open-traffic-generator/snappi/gosnappi v0.13.0
+	github.com/open-traffic-generator/snappi/gosnappi v0.12.6
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.7.0
 	google.golang.org/protobuf v1.31.0

--- a/go.sum
+++ b/go.sum
@@ -971,8 +971,8 @@ github.com/mum4k/termdash v0.18.0 h1:wpy3FKcVV5s2TOoMTKzqQXwL5VClZIlNrRqZDpeIzBA
 github.com/mum4k/termdash v0.18.0/go.mod h1:VWL18wLZDKVKF/f4TkMRiKZb9Eg8Ax99PtNuGuRAguw=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/open-traffic-generator/snappi/gosnappi v0.12.6 h1:is/B8naeu88yrw49Cmzp2R1tAfv064Vcm0yBjEdGXp0=
-github.com/open-traffic-generator/snappi/gosnappi v0.12.6/go.mod h1:OZQyKjTbwOiqLobQ26Wq/bJLVB0HollV7mKP7ciBR7M=
+github.com/open-traffic-generator/snappi/gosnappi v0.13.0 h1:RdlbT+CIlVum6xbhiFr/IzTvQee5bMa3V4oBWa79UBw=
+github.com/open-traffic-generator/snappi/gosnappi v0.13.0/go.mod h1:QjB939WFJqUq6V7RQqkY/LFCgRRzKrybHHFp7F7xdWA=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -1699,8 +1699,8 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
-google.golang.org/grpc v1.58.2 h1:SXUpjxeVF3FKrTYQI4f4KvbGD5u2xccdYdurwowix5I=
-google.golang.org/grpc v1.58.2/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
+google.golang.org/grpc v1.58.3 h1:BjnpXut1btbtgN/6sp+brB2Kbm2LjNXnidYujAVbSoQ=
+google.golang.org/grpc v1.58.3/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/go.sum
+++ b/go.sum
@@ -971,8 +971,8 @@ github.com/mum4k/termdash v0.18.0 h1:wpy3FKcVV5s2TOoMTKzqQXwL5VClZIlNrRqZDpeIzBA
 github.com/mum4k/termdash v0.18.0/go.mod h1:VWL18wLZDKVKF/f4TkMRiKZb9Eg8Ax99PtNuGuRAguw=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/open-traffic-generator/snappi/gosnappi v0.13.0 h1:RdlbT+CIlVum6xbhiFr/IzTvQee5bMa3V4oBWa79UBw=
-github.com/open-traffic-generator/snappi/gosnappi v0.13.0/go.mod h1:QjB939WFJqUq6V7RQqkY/LFCgRRzKrybHHFp7F7xdWA=
+github.com/open-traffic-generator/snappi/gosnappi v0.12.6 h1:is/B8naeu88yrw49Cmzp2R1tAfv064Vcm0yBjEdGXp0=
+github.com/open-traffic-generator/snappi/gosnappi v0.12.6/go.mod h1:OZQyKjTbwOiqLobQ26Wq/bJLVB0HollV7mKP7ciBR7M=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -1699,6 +1699,7 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
+google.golang.org/grpc v1.58.2/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc v1.58.3 h1:BjnpXut1btbtgN/6sp+brB2Kbm2LjNXnidYujAVbSoQ=
 google.golang.org/grpc v1.58.3/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=

--- a/go.sum
+++ b/go.sum
@@ -971,8 +971,8 @@ github.com/mum4k/termdash v0.18.0 h1:wpy3FKcVV5s2TOoMTKzqQXwL5VClZIlNrRqZDpeIzBA
 github.com/mum4k/termdash v0.18.0/go.mod h1:VWL18wLZDKVKF/f4TkMRiKZb9Eg8Ax99PtNuGuRAguw=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
-github.com/open-traffic-generator/snappi/gosnappi v0.12.3 h1:Qu9rAPvD98wgDzr1W7srtf7pkQsI8FXv3w6p76RHjcY=
-github.com/open-traffic-generator/snappi/gosnappi v0.12.3/go.mod h1:C1W8UKEsCCRX9j/bRmAWVd6prlZPqp5/jHzoCp3MMJI=
+github.com/open-traffic-generator/snappi/gosnappi v0.12.6 h1:is/B8naeu88yrw49Cmzp2R1tAfv064Vcm0yBjEdGXp0=
+github.com/open-traffic-generator/snappi/gosnappi v0.12.6/go.mod h1:OZQyKjTbwOiqLobQ26Wq/bJLVB0HollV7mKP7ciBR7M=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
 github.com/phpdave11/gofpdi v1.0.13/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
@@ -1699,8 +1699,8 @@ google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwS
 google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/grpc v1.55.0/go.mod h1:iYEXKGkEBhg1PjZQvoYEVPTDkHo1/bjTnfwTeGONTY8=
 google.golang.org/grpc v1.56.2/go.mod h1:I9bI3vqKfayGqPUAwGdOSu7kt6oIJLixfffKrpXqQ9s=
-google.golang.org/grpc v1.58.0 h1:32JY8YpPMSR45K+c3o6b8VL73V+rR8k+DeMIr4vRH8o=
-google.golang.org/grpc v1.58.0/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
+google.golang.org/grpc v1.58.2 h1:SXUpjxeVF3FKrTYQI4f4KvbGD5u2xccdYdurwowix5I=
+google.golang.org/grpc v1.58.2/go.mod h1:tgX3ZQDlNJGU96V6yHh1T/JeoBQ2TXdr43YbYSsCJk0=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=

--- a/test/systest/cpdp-frr/Makefile
+++ b/test/systest/cpdp-frr/Makefile
@@ -18,7 +18,7 @@ install: install-clab
 
 install-clab: /usr/bin/containerlab
 /usr/bin/containerlab:
-	bash -c "$$(curl -sL https://get.containerlab.dev)"
+	bash -c "$$(curl -sL https://get.containerlab.dev)" -- -v 0.46.2
 
 install-clean:
 	-sudo apt remove containerlab -y

--- a/test/systest/cpdp-frr/topo.clab.yml
+++ b/test/systest/cpdp-frr/topo.clab.yml
@@ -3,7 +3,7 @@ topology:
   nodes:
     ixc:
       kind: linux
-      image: ghcr.io/open-traffic-generator/keng-controller:0.0.1-5308
+      image: ghcr.io/open-traffic-generator/keng-controller:0.1.0-3
       network-mode: host
       cmd: --accept-eula --http-port 8443
       ports:
@@ -22,7 +22,7 @@ topology:
         WAIT_FOR_IFACE: Yes
     pe1:
       kind: linux
-      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.331
+      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.337
       network-mode: container:te1
       startup-delay: 5
       env:
@@ -48,7 +48,7 @@ topology:
         WAIT_FOR_IFACE: Yes
     pe2:
       kind: linux
-      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.331
+      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.337
       network-mode: container:te2
       startup-delay: 5
       env:

--- a/test/systest/cpdp-frr/topo.clab.yml
+++ b/test/systest/cpdp-frr/topo.clab.yml
@@ -3,14 +3,14 @@ topology:
   nodes:
     ixc:
       kind: linux
-      image: ghcr.io/open-traffic-generator/licensed/ixia-c-controller:0.0.1-4478
+      image: ghcr.io/open-traffic-generator/keng-controller:0.0.1-5308
       network-mode: host
       cmd: --accept-eula --http-port 8443
       ports:
         - 8443:8443
     te1:
       kind: linux
-      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.45
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.85
       ports:
         - 5555:5555
         - 50071:50071
@@ -22,7 +22,7 @@ topology:
         WAIT_FOR_IFACE: Yes
     pe1:
       kind: linux
-      image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.326
+      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.331
       network-mode: container:te1
       startup-delay: 5
       env:
@@ -36,7 +36,7 @@ topology:
       - ./frr/vtysh.conf:/etc/frr/vtysh.conf
     te2:
       kind: linux
-      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.45
+      image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.85
       ports:
         - 5556:5556
         - 50072:50071
@@ -48,7 +48,7 @@ topology:
         WAIT_FOR_IFACE: Yes
     pe2:
       kind: linux
-      image: ghcr.io/open-traffic-generator/licensed/ixia-c-protocol-engine:1.00.0.326
+      image: ghcr.io/open-traffic-generator/ixia-c-protocol-engine:1.00.0.331
       network-mode: container:te2
       startup-delay: 5
       env:

--- a/test/systest/dp-b2b/compose.yml
+++ b/test/systest/dp-b2b/compose.yml
@@ -1,6 +1,6 @@
 services:
   controller:
-    image: ghcr.io/open-traffic-generator/keng-controller:0.0.1-5308
+    image: ghcr.io/open-traffic-generator/keng-controller:0.1.0-3
     command: --accept-eula --http-port 8443
     network_mode: "host"
     restart: always

--- a/test/systest/dp-b2b/compose.yml
+++ b/test/systest/dp-b2b/compose.yml
@@ -1,11 +1,11 @@
 services:
   controller:
-    image: ghcr.io/open-traffic-generator/ixia-c-controller:0.0.1-4478
+    image: ghcr.io/open-traffic-generator/keng-controller:0.0.1-5308
     command: --accept-eula --http-port 8443
     network_mode: "host"
     restart: always
   traffic_engine_1:
-    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.45
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.85
     network_mode: "host"
     restart: always
     privileged: true
@@ -14,7 +14,7 @@ services:
     - ARG_IFACE_LIST=virtual@af_packet,veth0
     - OPT_NO_HUGEPAGES=Yes
   traffic_engine_2:
-    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.45
+    image: ghcr.io/open-traffic-generator/ixia-c-traffic-engine:1.6.0.85
     network_mode: "host"
     restart: always
     privileged: true


### PR DESCRIPTION
Updated to gosnappi v0.12.6 and fixed counters in transform to use uint64 type.
Updated systests to Ixia-c v0.1 which no longer requires access to private Ixia-c images for `cpdp-frr` testbed.
Can not update gosnappi to v0.13 from the Ixia-c v0.1 release due to issue reported here: https://github.com/open-traffic-generator/snappi/issues/213
Pinned containerlab to v0.46.2 as if upgrade to v0.47 the `cpdp-frr` testbed fails to start.